### PR TITLE
Read draft by ID

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetById.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetById.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.reform.draftstore.endpoint.v3;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
+import uk.gov.hmcts.reform.draftstore.domain.Draft;
+import uk.gov.hmcts.reform.draftstore.service.UserIdentificationService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(DraftController.class)
+public class GetById {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean private DraftStoreDAO draftRepo;
+    @MockBean private UserIdentificationService userIdentificationService;
+
+    private final Draft sampleDraft = new Draft(123, "abc", "", "");
+
+    @Test
+    public void reading_not_existing_draft_returns_404() throws Exception {
+        testStatus("abc", null, HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    public void reading_own_existing_draft_returns_200() throws Exception {
+        testStatus("abc", sampleDraft, HttpStatus.OK);
+    }
+
+    @Test
+    public void reading_somebody_elses_draft_returns_404() throws Exception {
+        testStatus("XXX", sampleDraft, HttpStatus.NOT_FOUND);
+    }
+
+    private void testStatus(
+        String userId,
+        Draft draftInDb,
+        HttpStatus expectedStatus
+    ) throws Exception {
+        // given
+        BDDMockito
+            .given(draftRepo.read(anyInt()))
+            .willReturn(Optional.ofNullable(draftInDb));
+
+        BDDMockito
+            .given(userIdentificationService.userIdFromAuthToken(anyString()))
+            .willReturn(userId);
+
+        // when
+        MvcResult result =
+            mockMvc
+                .perform(
+                    get("/drafts/123")
+                        .header(AUTHORIZATION, "irrelevant-header")
+                ).andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(expectedStatus.value());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
@@ -1,11 +1,17 @@
 package uk.gov.hmcts.reform.draftstore.data;
 
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import uk.gov.hmcts.reform.draftstore.domain.Draft;
 import uk.gov.hmcts.reform.draftstore.domain.SaveStatus;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 
 import static uk.gov.hmcts.reform.draftstore.domain.SaveStatus.Created;
 import static uk.gov.hmcts.reform.draftstore.domain.SaveStatus.Updated;
@@ -67,6 +73,21 @@ public class DraftStoreDAO {
         return documents.stream().findFirst().orElseThrow(NoDraftFoundException::new);
     }
 
+    public Optional<Draft> read(int draftId) {
+        try {
+            Draft draft =
+                jdbcTemplate
+                    .queryForObject(
+                        "SELECT * FROM draft_document WHERE id = :id",
+                        new MapSqlParameterSource("id", draftId),
+                        new DraftMapper()
+                    );
+            return Optional.of(draft);
+        } catch (EmptyResultDataAccessException ex) {
+            return Optional.empty();
+        }
+    }
+
     public void delete(String userId, String type) {
         int rows =
             jdbcTemplate.update(
@@ -77,6 +98,18 @@ public class DraftStoreDAO {
             );
         if (rows == 0) {
             throw new NoDraftFoundException();
+        }
+    }
+
+    private static final class DraftMapper implements RowMapper<Draft> {
+        @Override
+        public Draft mapRow(ResultSet rs, int rowNumber) throws SQLException {
+            return new Draft(
+                rs.getInt("id"),
+                rs.getString("user_id"),
+                rs.getString("document"),
+                rs.getString("document_type")
+            );
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
@@ -76,12 +76,11 @@ public class DraftStoreDAO {
     public Optional<Draft> read(int draftId) {
         try {
             Draft draft =
-                jdbcTemplate
-                    .queryForObject(
-                        "SELECT * FROM draft_document WHERE id = :id",
-                        new MapSqlParameterSource("id", draftId),
-                        new DraftMapper()
-                    );
+                jdbcTemplate.queryForObject(
+                    "SELECT * FROM draft_document WHERE id = :id",
+                    new MapSqlParameterSource("id", draftId),
+                    new DraftMapper()
+                );
             return Optional.of(draft);
         } catch (EmptyResultDataAccessException ex) {
             return Optional.empty();

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/domain/Draft.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/domain/Draft.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.draftstore.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+
+public class Draft {
+
+    public final int id;
+
+    @JsonIgnore
+    public final String userId;
+
+    @JsonRawValue
+    public final String document;
+
+    public final String type;
+
+    public Draft(int id, String userId, String document, String type) {
+        this.id = id;
+        this.userId = userId;
+        this.document = document;
+        this.type = type;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.draftstore.endpoint.v3;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
+import uk.gov.hmcts.reform.draftstore.domain.Draft;
+import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
+import uk.gov.hmcts.reform.draftstore.service.UserIdentificationService;
+
+import java.util.Objects;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RestController
+@RequestMapping("drafts")
+public class DraftController {
+
+    private final DraftStoreDAO draftRepo;
+    private final UserIdentificationService userIdService;
+
+    public DraftController(DraftStoreDAO draftRepo, UserIdentificationService userIdService) {
+        this.draftRepo = draftRepo;
+        this.userIdService = userIdService;
+    }
+
+    @GetMapping(path = "/{id}")
+    public Draft read(
+        @PathVariable int id,
+        @RequestHeader(AUTHORIZATION) String authHeader
+    ) {
+        String currentUserId = userIdService.userIdFromAuthToken(authHeader);
+        return draftRepo
+            .read(id)
+            .filter(draft -> Objects.equals(draft.userId, currentUserId))
+            .orElseThrow(() -> new NoDraftFoundException());
+    }
+}


### PR DESCRIPTION
### Change description ###

One of many changes around API changes. 
Adding an endpoint for retrieving single draft by its ID.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
