### PR TITLE
Read drafts without filtering by type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
@@ -67,6 +67,14 @@ public class DraftStoreDAO {
         );
     }
 
+    public List<Draft> readAll(String userId) {
+        return jdbcTemplate.query(
+            "SELECT * FROM draft_document WHERE user_id = :userId",
+            new MapSqlParameterSource("userId", userId),
+            new DraftMapper()
+        );
+    }
+
     public Optional<Draft> read(int draftId) {
         try {
             Draft draft =

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.draftstore.service.UserIdentificationService;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
@@ -42,10 +43,12 @@ public class DraftController {
 
     @GetMapping
     public List<Draft> readAll(
-        @RequestParam("type") String type,
+        @RequestParam(value = "type", required = false) String type,
         @RequestHeader(AUTHORIZATION) String authHeader
     ) {
         String currentUserId = userIdService.userIdFromAuthToken(authHeader);
-        return draftRepo.readAll(currentUserId, type);
+        return Optional.ofNullable(type)
+            .map(t -> draftRepo.readAll(currentUserId, t))
+            .orElseGet(() -> draftRepo.readAll(currentUserId));
     }
 }


### PR DESCRIPTION
### Change description ###

Now supports both `/drafts` and `/drafts?type=xyz`

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
