### PR TITLE
Wrap draft search results in a model

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetAllTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetAllTest.java
@@ -42,6 +42,6 @@ public class GetAllTest {
         mockMvc
             .perform(get("/drafts?type=default").header(AUTHORIZATION, "auth-header-value"))
             .andExpect(status().isOk())
-            .andExpect(content().json("[]"));
+            .andExpect(content().json("{ \"data\": [] }"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/domain/DraftList.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/domain/DraftList.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.draftstore.domain;
+
+import java.util.List;
+
+public class DraftList {
+
+    public final List<Draft> data;
+
+    public DraftList(List<Draft> data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
 import uk.gov.hmcts.reform.draftstore.domain.CreateDraft;
 import uk.gov.hmcts.reform.draftstore.domain.Draft;
+import uk.gov.hmcts.reform.draftstore.domain.DraftList;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 import uk.gov.hmcts.reform.draftstore.service.UserIdentificationService;
 
@@ -49,14 +50,18 @@ public class DraftController {
     }
 
     @GetMapping
-    public List<Draft> readAll(
+    public DraftList readAll(
         @RequestParam(value = "type", required = false) String type,
         @RequestHeader(AUTHORIZATION) String authHeader
     ) {
         String currentUserId = userIdService.userIdFromAuthToken(authHeader);
-        return Optional.ofNullable(type)
-            .map(t -> draftRepo.readAll(currentUserId, t))
-            .orElseGet(() -> draftRepo.readAll(currentUserId));
+
+        List<Draft> drafts =
+            Optional.ofNullable(type)
+                .map(t -> draftRepo.readAll(currentUserId, t))
+                .orElseGet(() -> draftRepo.readAll(currentUserId));
+
+        return new DraftList(drafts);
     }
 
     @PostMapping


### PR DESCRIPTION
So that it's in line with:
- https://hmcts.github.io/restful-api-standards/#167
- https://hmcts.github.io/restful-api-standards/#110

>In a response body, you must always return a JSON object (and not e.g. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and e.g. add pagination later, without breaking backwards compatibility.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
