### PR TITLE
Change draft id type to string

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DeleteTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DeleteTest.java
@@ -33,7 +33,8 @@ public class DeleteTest {
     @MockBean private DraftStoreDAO draftRepo;
     @MockBean private UserIdentificationService userIdentificationService;
 
-    private final Draft existingDraft = new Draft(123, "user", "doc", "type");
+    private static final int existingDraftId = 123;
+    private final Draft existingDraft = new Draft(Integer.toString(existingDraftId), "user", "doc", "type");
 
     @Before
     public void setUp() throws Exception {
@@ -42,7 +43,7 @@ public class DeleteTest {
             .willReturn(Optional.empty());
 
         BDDMockito
-            .given(draftRepo.read(eq(existingDraft.id)))
+            .given(draftRepo.read(eq(existingDraftId)))
             .willReturn(Optional.of(existingDraft));
 
         BDDMockito
@@ -56,19 +57,19 @@ public class DeleteTest {
 
     @Test
     public void should_return_403_when_trying_to_delete_somebody_elses_draft() throws Exception {
-        remove(existingDraft.id, "villain")
+        remove(existingDraftId, "villain")
             .andExpect(status().isForbidden());
     }
 
     @Test
     public void should_return_204_when_deleting_own_draft() throws Exception {
-        remove(existingDraft.id, existingDraft.userId)
+        remove(existingDraftId, existingDraft.userId)
             .andExpect(status().isNoContent());
     }
 
     @Test
     public void should_return_204_when_draft_with_given_id_doesnt_exist() throws Exception {
-        remove(existingDraft.id + 123, "some_user")
+        remove(existingDraftId + 123, "some_user")
             .andExpect(status().isNoContent());
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetByIdTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetByIdTest.java
@@ -31,7 +31,7 @@ public class GetByIdTest {
     @MockBean private DraftStoreDAO draftRepo;
     @MockBean private UserIdentificationService userIdentificationService;
 
-    private final Draft sampleDraft = new Draft(123, "abc", "", "");
+    private final Draft sampleDraft = new Draft("123", "abc", "", "");
 
     @Test
     public void reading_not_existing_draft_returns_404() throws Exception {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
@@ -33,7 +33,8 @@ public class UpdateTest {
     @MockBean private DraftStoreDAO draftRepo;
     @MockBean private UserIdentificationService userIdentificationService;
 
-    private final Draft existingDraft = new Draft(123, "user", "doc", "type");
+    private static final int existingDraftId = 123;
+    private final Draft existingDraft = new Draft(Integer.toString(existingDraftId), "user", "doc", "type");
 
     @Before
     public void setUp() throws Exception {
@@ -42,7 +43,7 @@ public class UpdateTest {
             .willReturn(Optional.empty());
 
         BDDMockito
-            .given(draftRepo.read(eq(existingDraft.id)))
+            .given(draftRepo.read(eq(existingDraftId)))
             .willReturn(Optional.of(existingDraft));
 
         BDDMockito
@@ -56,19 +57,19 @@ public class UpdateTest {
 
     @Test
     public void should_return_403_when_trying_to_update_somebody_elses_draft() throws Exception {
-        update(existingDraft.id, "villain")
+        update(existingDraftId, "villain")
             .andExpect(status().isForbidden());
     }
 
     @Test
     public void should_return_204_when_updating_own_draft() throws Exception {
-        update(existingDraft.id, existingDraft.userId)
+        update(existingDraftId, existingDraft.userId)
             .andExpect(status().isNoContent());
     }
 
     @Test
     public void should_return_404_when_draft_with_given_id_doesnt_exist() throws Exception {
-        update(existingDraft.id + 123, "some_user")
+        update(existingDraftId + 123, "some_user")
             .andExpect(status().isNotFound());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
@@ -145,7 +145,7 @@ public class DraftStoreDAO {
         @Override
         public Draft mapRow(ResultSet rs, int rowNumber) throws SQLException {
             return new Draft(
-                rs.getInt("id"),
+                rs.getString("id"),
                 rs.getString("user_id"),
                 rs.getString("document"),
                 rs.getString("document_type")

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/domain/Draft.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/domain/Draft.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonRawValue;
 
 public class Draft {
 
-    public final int id;
+    public final String id;
 
     @JsonIgnore
     public final String userId;
@@ -15,7 +15,7 @@ public class Draft {
 
     public final String type;
 
-    public Draft(int id, String userId, String document, String type) {
+    public Draft(String id, String userId, String document, String type) {
         this.id = id;
         this.userId = userId;
         this.document = document;

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
@@ -59,12 +59,12 @@ public class DraftController {
         @ApiResponse(code = 404, message = "Not found", response = ErrorResult.class),
     })
     public Draft read(
-        @PathVariable int id,
+        @PathVariable String id,
         @RequestHeader(AUTHORIZATION) String authHeader
     ) {
         String currentUserId = userIdService.userIdFromAuthToken(authHeader);
         return draftRepo
-            .read(id)
+            .read(toDbId(id))
             .filter(draft -> Objects.equals(draft.userId, currentUserId))
             .orElseThrow(() -> new NoDraftFoundException());
     }
@@ -114,17 +114,17 @@ public class DraftController {
         @ApiResponse(code = 404, message = "Not found", response = ErrorResult.class),
     })
     public ResponseEntity<Void> update(
-        @PathVariable int id,
+        @PathVariable String id,
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestBody @Valid UpdateDraft updatedDraft
     ) {
         String currentUserId = userIdService.userIdFromAuthToken(authHeader);
 
         return draftRepo
-            .read(id)
+            .read(toDbId(id))
             .map(d -> {
                 assertCanEdit(d, currentUserId);
-                draftRepo.update(id, updatedDraft);
+                draftRepo.update(toDbId(id), updatedDraft);
 
                 return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
             })
@@ -137,16 +137,16 @@ public class DraftController {
         @ApiResponse(code = 204, message = "Draft deleted")
     })
     public ResponseEntity<Void> delete(
-        @PathVariable int id,
+        @PathVariable String id,
         @RequestHeader(AUTHORIZATION) String authHeader
     ) {
         String currentUserId = userIdService.userIdFromAuthToken(authHeader);
 
         draftRepo
-            .read(id)
+            .read(toDbId(id))
             .ifPresent(d -> {
                 assertCanEdit(d, currentUserId);
-                draftRepo.delete(id);
+                draftRepo.delete(toDbId(id));
             });
 
         return noContent().build();
@@ -155,6 +155,14 @@ public class DraftController {
     private void assertCanEdit(Draft draft, String userId) {
         if (!Objects.equals(draft.userId, userId)) {
             throw new AuthorizationException();
+        }
+    }
+
+    private int toDbId(String apiId) {
+        try {
+            return Integer.parseInt(apiId);
+        } catch (NumberFormatException exc) {
+            throw new NoDraftFoundException();
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
@@ -64,7 +64,7 @@ public class DraftController {
     ) {
         String currentUserId = userIdService.userIdFromAuthToken(authHeader);
         return draftRepo
-            .read(toDbId(id))
+            .read(toInternalId(id))
             .filter(draft -> Objects.equals(draft.userId, currentUserId))
             .orElseThrow(() -> new NoDraftFoundException());
     }
@@ -121,10 +121,10 @@ public class DraftController {
         String currentUserId = userIdService.userIdFromAuthToken(authHeader);
 
         return draftRepo
-            .read(toDbId(id))
+            .read(toInternalId(id))
             .map(d -> {
                 assertCanEdit(d, currentUserId);
-                draftRepo.update(toDbId(id), updatedDraft);
+                draftRepo.update(toInternalId(id), updatedDraft);
 
                 return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
             })
@@ -143,10 +143,10 @@ public class DraftController {
         String currentUserId = userIdService.userIdFromAuthToken(authHeader);
 
         draftRepo
-            .read(toDbId(id))
+            .read(toInternalId(id))
             .ifPresent(d -> {
                 assertCanEdit(d, currentUserId);
-                draftRepo.delete(toDbId(id));
+                draftRepo.delete(toInternalId(id));
             });
 
         return noContent().build();
@@ -158,8 +158,12 @@ public class DraftController {
         }
     }
 
-    private int toDbId(String apiId) {
+    /**
+     * Converts external API id to internally used id
+     */
+    private int toInternalId(String apiId) {
         try {
+            // currently database ID is an int
             return Integer.parseInt(apiId);
         } catch (NumberFormatException exc) {
             throw new NoDraftFoundException();


### PR DESCRIPTION
## Change description ###
What: `id` field on returned model is now a string, not an int
Why: https://hmcts.github.io/restful-api-standards/#common-data-types


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
