### PR TITLE
Add information about service to draft

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DataAgent.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DataAgent.java
@@ -27,7 +27,8 @@ public class DataAgent {
         jsonbObj.setValue(document);
 
         jdbcTemplate.update(
-            "INSERT INTO draft_document (user_id, document_type, document) VALUES (:userId, :type, :document)",
+            "INSERT INTO draft_document (user_id, document_type, service, document) "
+                + "VALUES (:userId, :type, 'cmc', :document)",
             new MapSqlParameterSource("userId", userId)
                 .addValue("type", type)
                 .addValue("document", jsonbObj)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
@@ -45,19 +45,19 @@ public class DraftStoreDAOTest {
 
     @Test(expected = DataIntegrityViolationException.class)
     public void shouldThrowDataAccessExceptionWhenUserIdIsNull() {
-        underTest.insertOrUpdate(null, "defaultService", "default", PETITION);
+        underTest.insertOrUpdate(null, "cmc", "default", PETITION);
     }
 
     @Test(expected = DataIntegrityViolationException.class)
     public void shouldThrowDataAccessExceptionWhenDocumentIsInvalidJson() {
-        underTest.insertOrUpdate(USER_ID, "defaultService", "default", "{not valid json}");
+        underTest.insertOrUpdate(USER_ID, "cmc", "default", "{not valid json}");
     }
 
     @Test
     public void shouldCreateDraftDocument() {
         givenExistingDocument(ANOTHER_USER_ID, ANOTHER_PETITION);
 
-        SaveStatus saveStatus = underTest.insertOrUpdate(USER_ID, "defaultService", "default", PETITION);
+        SaveStatus saveStatus = underTest.insertOrUpdate(USER_ID, "cmc", "default", PETITION);
 
         assertThat(saveStatus).isEqualTo(Created);
         String actual = dataAgent.documentForUser(USER_ID, "default");
@@ -70,7 +70,7 @@ public class DraftStoreDAOTest {
         givenExistingDocument(USER_ID, PETITION);
         givenExistingDocument(ANOTHER_USER_ID, ANOTHER_PETITION);
 
-        SaveStatus saveStatus = underTest.insertOrUpdate(USER_ID, "defaultService", "default", PETITION_UPDATE);
+        SaveStatus saveStatus = underTest.insertOrUpdate(USER_ID, "cmc", "default", PETITION_UPDATE);
 
         assertThat(saveStatus).isEqualTo(Updated);
         String actual = dataAgent.documentForUser(USER_ID, "default");
@@ -99,7 +99,7 @@ public class DraftStoreDAOTest {
         dataAgent.setupDocumentForUser(USER_ID, "default", "{ \"test\":\"1234\"}");
         givenExistingDocument(ANOTHER_USER_ID, ANOTHER_PETITION);
 
-        List<Draft> drafts = underTest.readAll(USER_ID, "default");
+        List<Draft> drafts = underTest.readAll(USER_ID, "cmc", "default");
 
         assertThat(drafts.size()).isEqualTo(1);
         assertThat(drafts.get(0).document).isEqualTo("{ \"test\":\"1234\"}");
@@ -108,7 +108,7 @@ public class DraftStoreDAOTest {
 
     @Test
     public void readAll_should_return_empty_list_when_no_drafts_found() {
-        List<Draft> drafts = underTest.readAll("abc", "xyz");
+        List<Draft> drafts = underTest.readAll("abc", "cmc", "xyz");
         assertThat(drafts).isEmpty();
     }
 
@@ -117,18 +117,18 @@ public class DraftStoreDAOTest {
         dataAgent.setupDocumentForUser("id", "t", "[1]");
         dataAgent.setupDocumentForUser("id", "t", "[2]");
 
-        List<Draft> drafts = underTest.readAll("id", "t");
+        List<Draft> drafts = underTest.readAll("id", "cmc", "t");
 
         assertThat(drafts).hasSize(2);
         assertThat(drafts).extracting("document").contains("[1]", "[2]");
     }
 
     private void givenExistingDocument(String userId, String document) {
-        underTest.insertOrUpdate(userId, "defaultService","default", document);
+        underTest.insertOrUpdate(userId, "cmc","default", document);
     }
 
     private void assertNoOtherUserDataHasBeenAffected() {
-        List<Draft> otherUserDrafts = underTest.readAll(ANOTHER_USER_ID, "default");
+        List<Draft> otherUserDrafts = underTest.readAll(ANOTHER_USER_ID, "cmc", "default");
         assertThat(otherUserDrafts.size()).isEqualTo(1);
         assertThat(otherUserDrafts.get(0).document).isEqualTo(ANOTHER_PETITION);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
@@ -45,19 +45,19 @@ public class DraftStoreDAOTest {
 
     @Test(expected = DataIntegrityViolationException.class)
     public void shouldThrowDataAccessExceptionWhenUserIdIsNull() {
-        underTest.insertOrUpdate(null, "default", PETITION);
+        underTest.insertOrUpdate(null, "defaultService", "default", PETITION);
     }
 
     @Test(expected = DataIntegrityViolationException.class)
     public void shouldThrowDataAccessExceptionWhenDocumentIsInvalidJson() {
-        underTest.insertOrUpdate(USER_ID, "default", "{not valid json}");
+        underTest.insertOrUpdate(USER_ID, "defaultService", "default", "{not valid json}");
     }
 
     @Test
     public void shouldCreateDraftDocument() {
         givenExistingDocument(ANOTHER_USER_ID, ANOTHER_PETITION);
 
-        SaveStatus saveStatus = underTest.insertOrUpdate(USER_ID, "default", PETITION);
+        SaveStatus saveStatus = underTest.insertOrUpdate(USER_ID, "defaultService", "default", PETITION);
 
         assertThat(saveStatus).isEqualTo(Created);
         String actual = dataAgent.documentForUser(USER_ID, "default");
@@ -70,7 +70,7 @@ public class DraftStoreDAOTest {
         givenExistingDocument(USER_ID, PETITION);
         givenExistingDocument(ANOTHER_USER_ID, ANOTHER_PETITION);
 
-        SaveStatus saveStatus = underTest.insertOrUpdate(USER_ID, "default", PETITION_UPDATE);
+        SaveStatus saveStatus = underTest.insertOrUpdate(USER_ID, "defaultService", "default", PETITION_UPDATE);
 
         assertThat(saveStatus).isEqualTo(Updated);
         String actual = dataAgent.documentForUser(USER_ID, "default");
@@ -124,7 +124,7 @@ public class DraftStoreDAOTest {
     }
 
     private void givenExistingDocument(String userId, String document) {
-        underTest.insertOrUpdate(userId, "default", document);
+        underTest.insertOrUpdate(userId, "defaultService","default", document);
     }
 
     private void assertNoOtherUserDataHasBeenAffected() {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/HandleUnknownExceptionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/HandleUnknownExceptionTest.java
@@ -9,15 +9,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
+import uk.gov.hmcts.reform.draftstore.service.UserIdentificationService;
 
 import java.util.UUID;
 
 import static com.jayway.restassured.RestAssured.given;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.draftstore.service.UserIdentificationService.SERVICE_HEADER;
 
 /*
 Test for DIV-881 - the exception handler was returning too much information from
@@ -40,13 +43,14 @@ public class HandleUnknownExceptionTest {
 
     @Test
     public void unhandledExceptionsShouldNotReturnExceptionDetailsToClient() throws Exception {
-        when(dao.readAll(USER_ID))
+        when(dao.readAll(anyString(), anyString()))
             .thenThrow(new RuntimeException("do not display this message") { });
 
         given()
             .port(port)
             .accept(APPLICATION_JSON_VALUE)
             .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(SERVICE_HEADER, "some-service")
             .when()
             .get(DRAFT_URI)
             .then()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/CreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/CreateTest.java
@@ -22,6 +22,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.draftstore.service.UserIdentificationService.SERVICE_HEADER;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(DraftController.class)
@@ -73,7 +74,7 @@ public class CreateTest {
         final int newClaimId = 444;
 
         BDDMockito
-            .given(draftRepo.insert(anyString(), any(CreateDraft.class)))
+            .given(draftRepo.insert(anyString(), anyString(), any(CreateDraft.class)))
             .willReturn(newClaimId);
 
         MvcResult result = send("{ \"type\": \"some_type\", \"document\": {\"a\":\"b\"} }").andReturn();
@@ -86,6 +87,7 @@ public class CreateTest {
             .perform(
                 post("/drafts")
                     .header(AUTHORIZATION, "auth-header-value")
+                    .header(SERVICE_HEADER, "some_service_name")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(content)
             );

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DeleteTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DeleteTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Matchers.eq;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.draftstore.service.UserIdentificationService.SERVICE_HEADER;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(DraftController.class)
@@ -34,7 +35,7 @@ public class DeleteTest {
     @MockBean private UserIdentificationService userIdentificationService;
 
     private static final int existingDraftId = 123;
-    private final Draft existingDraft = new Draft(Integer.toString(existingDraftId), "user", "doc", "type");
+    private final Draft existingDraft = new Draft(Integer.toString(existingDraftId), "user", "serviceA", "doc", "type");
 
     @Before
     public void setUp() throws Exception {
@@ -53,31 +54,46 @@ public class DeleteTest {
         BDDMockito
             .given(userIdentificationService.userIdFromAuthToken(existingDraft.userId))
             .willReturn(existingDraft.userId);
+
+        BDDMockito
+            .given(userIdentificationService.getServiceName(anyString()))
+            .willReturn("definitely_not_" + existingDraft.service);
+
+        BDDMockito
+            .given(userIdentificationService.getServiceName(existingDraft.service))
+            .willReturn(existingDraft.service);
     }
 
     @Test
     public void should_return_403_when_trying_to_delete_somebody_elses_draft() throws Exception {
-        remove(existingDraftId, "villain")
+        remove(existingDraftId, "villain", existingDraft.service)
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void should_return_403_when_trying_to_delete_draft_from_aonther_service() throws Exception {
+        remove(existingDraftId, existingDraft.userId, "NOT_" + existingDraft.service)
             .andExpect(status().isForbidden());
     }
 
     @Test
     public void should_return_204_when_deleting_own_draft() throws Exception {
-        remove(existingDraftId, existingDraft.userId)
+        remove(existingDraftId, existingDraft.userId, existingDraft.service)
             .andExpect(status().isNoContent());
     }
 
     @Test
     public void should_return_204_when_draft_with_given_id_doesnt_exist() throws Exception {
-        remove(existingDraftId + 123, "some_user")
+        remove(existingDraftId + 123, "some_user", "some_service")
             .andExpect(status().isNoContent());
     }
 
-    private ResultActions remove(int draftId, String userId) throws Exception {
+    private ResultActions remove(int draftId, String userId, String service) throws Exception {
         return mockMvc
             .perform(
                 delete("/drafts/" + draftId)
                     .header(AUTHORIZATION, userId)
+                    .header(SERVICE_HEADER, service)
                     .contentType(MediaType.APPLICATION_JSON)
             );
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetAllTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetAllTest.java
@@ -18,6 +18,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.draftstore.service.UserIdentificationService.SERVICE_HEADER;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(DraftController.class)
@@ -40,7 +41,11 @@ public class GetAllTest {
             .willReturn("x");
 
         mockMvc
-            .perform(get("/drafts?type=default").header(AUTHORIZATION, "auth-header-value"))
+            .perform(
+                get("/drafts?type=default")
+                    .header(AUTHORIZATION, "auth-header-value")
+                    .header(SERVICE_HEADER, "some_service_name")
+            )
             .andExpect(status().isOk())
             .andExpect(content().json("{ \"data\": [] }"));
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetByIdTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetByIdTest.java
@@ -36,21 +36,27 @@ public class GetByIdTest {
 
     @Test
     public void reading_not_existing_draft_returns_404() throws Exception {
-        testStatus("abc", null, HttpStatus.NOT_FOUND);
+        testStatus("abc", "serviceA", null, HttpStatus.NOT_FOUND);
     }
 
     @Test
     public void reading_own_existing_draft_returns_200() throws Exception {
-        testStatus("abc", sampleDraft, HttpStatus.OK);
+        testStatus("abc", "serviceA", sampleDraft, HttpStatus.OK);
     }
 
     @Test
     public void reading_somebody_elses_draft_returns_404() throws Exception {
-        testStatus("XXX", sampleDraft, HttpStatus.NOT_FOUND);
+        testStatus("XXX", "serviceA", sampleDraft, HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    public void reading_own_draft_from_different_service_returns_404() throws Exception {
+        testStatus("abc", "WRONG_SERVICE", sampleDraft, HttpStatus.NOT_FOUND);
     }
 
     private void testStatus(
         String userId,
+        String service,
         Draft draftInDb,
         HttpStatus expectedStatus
     ) throws Exception {
@@ -62,6 +68,10 @@ public class GetByIdTest {
         BDDMockito
             .given(userIdentificationService.userIdFromAuthToken(anyString()))
             .willReturn(userId);
+
+        BDDMockito
+            .given(userIdentificationService.getServiceName(anyString()))
+            .willReturn(service);
 
         // when
         MvcResult result =

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetByIdTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetByIdTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static uk.gov.hmcts.reform.draftstore.service.UserIdentificationService.SERVICE_HEADER;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(DraftController.class)
@@ -31,7 +32,7 @@ public class GetByIdTest {
     @MockBean private DraftStoreDAO draftRepo;
     @MockBean private UserIdentificationService userIdentificationService;
 
-    private final Draft sampleDraft = new Draft("123", "abc", "", "");
+    private final Draft sampleDraft = new Draft("123", "abc", "serviceA", "", "");
 
     @Test
     public void reading_not_existing_draft_returns_404() throws Exception {
@@ -68,6 +69,7 @@ public class GetByIdTest {
                 .perform(
                     get("/drafts/123")
                         .header(AUTHORIZATION, "irrelevant-header")
+                        .header(SERVICE_HEADER, "irrelevant-service-name")
                 ).andReturn();
 
         // then

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Matchers.eq;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.draftstore.service.UserIdentificationService.SERVICE_HEADER;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(DraftController.class)
@@ -34,7 +35,7 @@ public class UpdateTest {
     @MockBean private UserIdentificationService userIdentificationService;
 
     private static final int existingDraftId = 123;
-    private final Draft existingDraft = new Draft(Integer.toString(existingDraftId), "user", "doc", "type");
+    private final Draft existingDraft = new Draft(Integer.toString(existingDraftId), "user", "serviceA","doc", "type");
 
     @Before
     public void setUp() throws Exception {
@@ -53,31 +54,44 @@ public class UpdateTest {
         BDDMockito
             .given(userIdentificationService.userIdFromAuthToken(existingDraft.userId))
             .willReturn(existingDraft.userId);
+
+        BDDMockito
+            .given(userIdentificationService.getServiceName(anyString()))
+            .willReturn("definitely_not_" + existingDraft.service);
+
+        BDDMockito
+            .given(userIdentificationService.getServiceName(existingDraft.service))
+            .willReturn(existingDraft.service);
     }
 
     @Test
     public void should_return_403_when_trying_to_update_somebody_elses_draft() throws Exception {
-        update(existingDraftId, "villain")
+        update(existingDraftId, "villain", existingDraft.service)
             .andExpect(status().isForbidden());
+    }
+
+    public void should_return_403_when_trying_to_update_draft_from_a_different_service() throws Exception {
+        update(existingDraftId, existingDraft.userId, "wrong_service");
     }
 
     @Test
     public void should_return_204_when_updating_own_draft() throws Exception {
-        update(existingDraftId, existingDraft.userId)
+        update(existingDraftId, existingDraft.userId, existingDraft.service)
             .andExpect(status().isNoContent());
     }
 
     @Test
     public void should_return_404_when_draft_with_given_id_doesnt_exist() throws Exception {
-        update(existingDraftId + 123, "some_user")
+        update(existingDraftId + 123, "some_user", "some_service")
             .andExpect(status().isNotFound());
     }
 
-    private ResultActions update(int draftId, String userId) throws Exception {
+    private ResultActions update(int draftId, String userId, String service) throws Exception {
         return mockMvc
             .perform(
                 put("/drafts/" + draftId)
                     .header(AUTHORIZATION, userId)
+                    .header(SERVICE_HEADER, service)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{ \"type\": \"some_type\", \"document\": {\"a\":\"b\"} }")
             );

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/domain/Draft.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/domain/Draft.java
@@ -10,14 +10,18 @@ public class Draft {
     @JsonIgnore
     public final String userId;
 
+    @JsonIgnore
+    public final String service;
+
     @JsonRawValue
     public final String document;
 
     public final String type;
 
-    public Draft(String id, String userId, String document, String type) {
+    public Draft(String id, String userId, String service, String document, String type) {
         this.id = id;
         this.userId = userId;
+        this.service = service;
         this.document = document;
         this.type = type;
     }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v2/DraftStoreEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v2/DraftStoreEndpoint.java
@@ -55,7 +55,7 @@ public class DraftStoreEndpoint {
         LOGGER.info("saving draft document");
 
         String userId = userIdService.userIdFromAuthToken(authToken);
-        SaveStatus saveStatus = draftStoreDao.insertOrUpdate(userId, type, document);
+        SaveStatus saveStatus = draftStoreDao.insertOrUpdate(userId, "cmc", type, document);
         return new ResponseEntity<>(saveStatus == Updated ? NO_CONTENT : CREATED);
     }
 
@@ -71,7 +71,7 @@ public class DraftStoreEndpoint {
 
         String document =
             draftStoreDao
-                .readAll(userId, type)
+                .readAll(userId, "cmc", type)
                 .stream()
                 .map(draft -> draft.document)
                 .findFirst()

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/UserIdentificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/UserIdentificationService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.draftstore.service;
 import org.springframework.util.StringUtils;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 
+import java.util.Optional;
 import javax.validation.constraints.NotNull;
 
 /*
@@ -14,6 +15,7 @@ Initially the implementation did indeed send a request to IDAM's /details endpoi
  */
 public class UserIdentificationService {
 
+    public static final String SERVICE_HEADER = "ServiceAuthorization";
     public static final String AUTH_TYPE = "hmcts-id ";
 
     public String userIdFromAuthToken(@NotNull String authToken) {
@@ -27,5 +29,13 @@ public class UserIdentificationService {
         throw new AuthorizationException(
             "Authorization token must be given in following format: '" + AUTH_TYPE + "<userId>'"
         );
+    }
+
+    public String getServiceName(@NotNull String serviceToken) {
+        // TODO: use jwt tokens
+        return Optional
+            .ofNullable(serviceToken)
+            .filter(token -> !StringUtils.isEmpty(token))
+            .orElseThrow(() -> new AuthorizationException(SERVICE_HEADER + " is required"));
     }
 }

--- a/src/main/resources/db/migration/V4__add_service_column.sql
+++ b/src/main/resources/db/migration/V4__add_service_column.sql
@@ -1,0 +1,8 @@
+ALTER TABLE draft_document ADD COLUMN service VARCHAR NULL;
+
+-- only cmc uses draft store atm
+UPDATE draft_document
+SET service = 'cmc'
+WHERE service IS NULL;
+
+ALTER TABLE draft_document ALTER COLUMN service SET NOT NULL;


### PR DESCRIPTION
### Change description ###
Add information to draft about service that created it.   
Old api uses hardcoded 'cmc' for backwards compatibility.  
New api requires `ServiceAuthorization` header for all operations.

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes (in v3, v2 remains the same)
[ ] No
```
