### PR TITLE
use idam for user auth

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/CreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/CreateTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.draftstore.endpoint.v3;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
@@ -15,7 +14,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
 import uk.gov.hmcts.reform.draftstore.domain.CreateDraft;
 import uk.gov.hmcts.reform.draftstore.service.AuthService;
-import uk.gov.hmcts.reform.draftstore.service.idam.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/CreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/CreateTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.draftstore.endpoint.v3;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
@@ -14,6 +15,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
 import uk.gov.hmcts.reform.draftstore.domain.CreateDraft;
 import uk.gov.hmcts.reform.draftstore.service.AuthService;
+import uk.gov.hmcts.reform.draftstore.service.idam.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DeleteTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DeleteTest.java
@@ -48,11 +48,11 @@ public class DeleteTest {
             .willReturn(Optional.of(existingDraft));
 
         BDDMockito
-            .given(authService.userIdFromAuthToken(anyString()))
+            .given(authService.getUserId(anyString()))
             .willReturn("definitely_not_" + existingDraft.userId);
 
         BDDMockito
-            .given(authService.userIdFromAuthToken(existingDraft.userId))
+            .given(authService.getUserId(existingDraft.userId))
             .willReturn(existingDraft.userId);
 
         BDDMockito

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetAllTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetAllTest.java
@@ -37,7 +37,7 @@ public class GetAllTest {
             .willReturn(Collections.emptyList());
 
         BDDMockito
-            .given(authService.userIdFromAuthToken(anyString()))
+            .given(authService.getUserId(anyString()))
             .willReturn("x");
 
         mockMvc

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetByIdTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/GetByIdTest.java
@@ -66,7 +66,7 @@ public class GetByIdTest {
             .willReturn(Optional.ofNullable(draftInDb));
 
         BDDMockito
-            .given(authService.userIdFromAuthToken(anyString()))
+            .given(authService.getUserId(anyString()))
             .willReturn(userId);
 
         BDDMockito

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
@@ -48,11 +48,11 @@ public class UpdateTest {
             .willReturn(Optional.of(existingDraft));
 
         BDDMockito
-            .given(authService.userIdFromAuthToken(anyString()))
+            .given(authService.getUserId(anyString()))
             .willReturn("definitely_not_" + existingDraft.userId);
 
         BDDMockito
-            .given(authService.userIdFromAuthToken(existingDraft.userId))
+            .given(authService.getUserId(existingDraft.userId))
             .willReturn(existingDraft.userId);
 
         BDDMockito

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/config/DraftStoreConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/config/DraftStoreConfig.java
@@ -1,12 +1,16 @@
 package uk.gov.hmcts.reform.draftstore.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
-import uk.gov.hmcts.reform.draftstore.service.AuthService;
+import uk.gov.hmcts.reform.draftstore.service.idam.IdamClient;
+import uk.gov.hmcts.reform.draftstore.service.idam.IdamClientImpl;
+import uk.gov.hmcts.reform.draftstore.service.idam.IdamClientStub;
 import uk.gov.hmcts.reform.logging.filters.RequestIdsSettingFilter;
 import uk.gov.hmcts.reform.logging.filters.RequestStatusLoggingFilter;
 
@@ -14,6 +18,9 @@ import javax.servlet.Filter;
 
 @Configuration
 public class DraftStoreConfig {
+
+    @Value("${idam.url}") private String idamUrl;
+
     @Bean
     MethodValidationPostProcessor methodValidationPostProcessor() {
         return new MethodValidationPostProcessor();
@@ -30,8 +37,15 @@ public class DraftStoreConfig {
     }
 
     @Bean
-    public AuthService authService() {
-        return new AuthService();
+    @ConditionalOnProperty(name = "idam.useStub", havingValue = "true")
+    public IdamClient idamClientStub() {
+        return new IdamClientStub();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "idam.useStub", havingValue = "false")
+    public IdamClient idamClient() {
+        return new IdamClientImpl(idamUrl);
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/EndpointExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/EndpointExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.draftstore.endpoint.domain.ErrorResult;
@@ -130,4 +131,12 @@ public class EndpointExceptionHandler extends ResponseEntityExceptionHandler {
         );
     }
 
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<ErrorResult> unknownException(HttpServletRequest req, HttpClientErrorException exc) {
+        log.warn(exc.getMessage(), exc);
+        return new ResponseEntity<>(
+            new ErrorResult(INVALID_AUTH_TOKEN, emptyList()),
+            exc.getStatusCode()
+        );
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
@@ -64,7 +64,7 @@ public class DraftController {
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestHeader(SERVICE_HEADER) String serviceHeader
     ) {
-        String currentUserId = authService.userIdFromAuthToken(authHeader);
+        String currentUserId = authService.getUserId(authHeader);
         String service = authService.getServiceName(serviceHeader);
 
         return draftRepo
@@ -84,7 +84,7 @@ public class DraftController {
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestHeader(SERVICE_HEADER) String serviceHeader
     ) {
-        String currentUserId = authService.userIdFromAuthToken(authHeader);
+        String currentUserId = authService.getUserId(authHeader);
         String service = authService.getServiceName(serviceHeader);
 
         List<Draft> drafts =
@@ -106,7 +106,7 @@ public class DraftController {
         @RequestHeader(SERVICE_HEADER) String serviceHeader,
         @RequestBody @Valid CreateDraft newDraft
     ) {
-        String currentUserId = authService.userIdFromAuthToken(authHeader);
+        String currentUserId = authService.getUserId(authHeader);
         String service = authService.getServiceName(serviceHeader);
 
         int id = draftRepo.insert(currentUserId, service, newDraft);
@@ -129,7 +129,7 @@ public class DraftController {
         @RequestHeader(SERVICE_HEADER) String serviceHeader,
         @RequestBody @Valid UpdateDraft updatedDraft
     ) {
-        String currentUserId = authService.userIdFromAuthToken(authHeader);
+        String currentUserId = authService.getUserId(authHeader);
         String service = authService.getServiceName(serviceHeader);
 
         return draftRepo
@@ -153,7 +153,7 @@ public class DraftController {
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestHeader(SERVICE_HEADER) String serviceHeader
     ) {
-        String currentUserId = authService.userIdFromAuthToken(authHeader);
+        String currentUserId = authService.getUserId(authHeader);
         String service = authService.getServiceName(serviceHeader);
 
         draftRepo

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/AuthService.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/AuthService.java
@@ -1,7 +1,10 @@
 package uk.gov.hmcts.reform.draftstore.service;
 
+import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
+import uk.gov.hmcts.reform.draftstore.service.idam.IdamClient;
+import uk.gov.hmcts.reform.draftstore.service.idam.User;
 
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
@@ -13,11 +16,19 @@ For tactical reasons, no IDAM stubs/not deployed anywhere, Divorce BA's decided 
 Initially the implementation did indeed send a request to IDAM's /details endpoint to get the documenter's user id
 @see http://git.reform/divorce/draft-document-store/commit/91839f84e54e42f5b70f28c68a150ad60ef86b9e
  */
+@Service
 public class AuthService {
 
     public static final String SERVICE_HEADER = "ServiceAuthorization";
     public static final String AUTH_TYPE = "hmcts-id ";
 
+    public final IdamClient idamClient;
+
+    public AuthService(IdamClient idamClient) {
+        this.idamClient = idamClient;
+    }
+
+    @Deprecated
     public String userIdFromAuthToken(@NotNull String authToken) {
         if (authToken.startsWith(AUTH_TYPE)) {
             String userId = authToken.replace(AUTH_TYPE, "");
@@ -29,6 +40,10 @@ public class AuthService {
         throw new AuthorizationException(
             "Authorization token must be given in following format: '" + AUTH_TYPE + "<userId>'"
         );
+    }
+
+    public String getUserId(@NotNull String authHeader) {
+        return idamClient.getUserDetails(authHeader).id;
     }
 
     public String getServiceName(@NotNull String serviceToken) {

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/AuthService.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/AuthService.java
@@ -4,18 +4,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 import uk.gov.hmcts.reform.draftstore.service.idam.IdamClient;
-import uk.gov.hmcts.reform.draftstore.service.idam.User;
 
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
 
-/*
-TODO: implementation of this service should be replaced with a request to the IDAM /details service (to get the userid)
-The auth header should have a Bearer JWT token.
-For tactical reasons, no IDAM stubs/not deployed anywhere, Divorce BA's decided to go with this solution.
-Initially the implementation did indeed send a request to IDAM's /details endpoint to get the documenter's user id
-@see http://git.reform/divorce/draft-document-store/commit/91839f84e54e42f5b70f28c68a150ad60ef86b9e
- */
 @Service
 public class AuthService {
 

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClient.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.reform.draftstore.service.idam;
+
+public interface IdamClient {
+    User getUserDetails(String authHeader);
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientImpl.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.draftstore.service.idam;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+public class IdamClientImpl implements IdamClient {
+
+    private final RestTemplate restTemplate;
+    private final String idamUrl;
+
+    public IdamClientImpl(final String idamUrl) {
+        this.restTemplate = new RestTemplate();
+        this.idamUrl = idamUrl;
+    }
+
+    @Override
+    public User getUserDetails(String authHeader) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(AUTHORIZATION, authHeader);
+
+        return restTemplate
+            .exchange(
+                idamUrl + "/details",
+                HttpMethod.GET,
+                new HttpEntity<String>(headers),
+                User.class
+            ).getBody();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientStub.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientStub.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.draftstore.service.idam;
+
+public class IdamClientStub implements IdamClient {
+
+    @Override
+    public User getUserDetails(String authHeader) {
+        return new User(authHeader, "example@example.com");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/User.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/User.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.draftstore.service.idam;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class User {
+    public final String id;
+    public final String email;
+
+    public User(
+        @JsonProperty("id") String id,
+        @JsonProperty("email") String email
+    ) {
+        this.id = id;
+        this.email = email;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,10 @@ info:
   app:
     name: ${spring.application.name}
 
+idam:
+  url: ${IDAM_URL}
+  useStub: ${IDAM_USE_STUB:false}
+
 ---
 spring:
   profiles: test
@@ -50,3 +54,5 @@ spring:
   datasource:
     url: jdbc:postgresql://localhost:${DRAFT_STORE_DB_PORT:5432}/draftstore
     password: ${DRAFT_STORE_DB_PASSWORD:}
+idam:
+  useStub: true

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/AuthServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
+import uk.gov.hmcts.reform.draftstore.service.idam.IdamClientStub;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -18,7 +19,7 @@ public class AuthServiceTest {
 
     @Before
     public void setUp() {
-        underTest = new AuthService();
+        underTest = new AuthService(new IdamClientStub());
     }
 
     @Test


### PR DESCRIPTION
Handle jwt in `Authorization` header (users only for now) in the new api by sending a request to Idam.

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes (v3 only)
[ ] No
```
