### PR TITLE
Filter drafts by json doc content

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
@@ -96,13 +96,13 @@ public class DraftStoreDAOTest {
 
     @Test
     public void shouldRetrieve() throws SQLException {
-        dataAgent.setupDocumentForUser(USER_ID, "default", "{ \"test\":\"1234\"}");
+        dataAgent.setupDocumentForUser(USER_ID, "default", "{\"test\": \"1234\"}");
         givenExistingDocument(ANOTHER_USER_ID, ANOTHER_PETITION);
 
         List<Draft> drafts = underTest.readAll(USER_ID, "cmc", "default");
 
         assertThat(drafts.size()).isEqualTo(1);
-        assertThat(drafts.get(0).document).isEqualTo("{ \"test\":\"1234\"}");
+        assertThat(drafts.get(0).document).isEqualTo("{\"test\": \"1234\"}");
         assertNoOtherUserDataHasBeenAffected();
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 import java.sql.SQLException;
 import java.util.List;
 
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.draftstore.domain.SaveStatus.Created;
 import static uk.gov.hmcts.reform.draftstore.domain.SaveStatus.Updated;
@@ -121,6 +122,18 @@ public class DraftStoreDAOTest {
 
         assertThat(drafts).hasSize(2);
         assertThat(drafts).extracting("document").contains("[1]", "[2]");
+    }
+
+    @Test
+    public void readAll_should_filter_by_json_document_content() throws Exception {
+        dataAgent.setupDocumentForUser("id", "t", "{\"some_property\": \"123\"}");
+        dataAgent.setupDocumentForUser("id", "t", "{\"some_property\": 99999}");
+        dataAgent.setupDocumentForUser("id", "t", "{\"a\": 5}");
+
+        List<Draft> drafts = underTest.readAll("id", "cmc", singletonMap("some_property", "123"));
+
+        assertThat(drafts).hasSize(1);
+        assertThat(drafts).extracting("document").containsExactly("{\"some_property\": \"123\"}");
     }
 
     private void givenExistingDocument(String userId, String document) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/OldDraftsCleanupTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/OldDraftsCleanupTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.draftstore.data;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,8 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 public class OldDraftsCleanupTest {
 
-    @Autowired
-    private NamedParameterJdbcTemplate jdbcTemplate;
+    @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+    @Autowired private ObjectMapper objectMapper;
     private Instant now = now();
 
     @Test
@@ -67,6 +68,7 @@ public class OldDraftsCleanupTest {
     private DraftStoreDAO repoAtTime(Instant instant) {
         return new DraftStoreDAO(
             jdbcTemplate,
+            objectMapper,
             0,
             Clock.fixed(instant, ZoneId.systemDefault())
         );

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/config/DraftStoreConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/config/DraftStoreConfig.java
@@ -42,9 +42,10 @@ public class DraftStoreConfig {
     }
 
     @Bean
-    public DraftStoreDAO draftDocumentDAO(NamedParameterJdbcTemplate jdbcTemplate) {
+    public DraftStoreDAO draftDocumentDAO(NamedParameterJdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
         return new DraftStoreDAO(
             jdbcTemplate,
+            objectMapper,
             maxStaleDaysDefault,
             Clock.systemDefaultZone()
         );

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
@@ -28,8 +28,8 @@ import uk.gov.hmcts.reform.draftstore.service.AuthService;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import javax.validation.Valid;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -80,7 +80,7 @@ public class DraftController {
         @ApiResponse(code = 200, message = "Success"),
     })
     public DraftList readAll(
-        @RequestParam(value = "type", required = false) String type,
+        @RequestParam(required = false) Map<String, String> params,
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestHeader(SERVICE_HEADER) String serviceHeader
     ) {
@@ -88,9 +88,9 @@ public class DraftController {
         String service = authService.getServiceName(serviceHeader);
 
         List<Draft> drafts =
-            Optional.ofNullable(type)
-                .map(t -> draftRepo.readAll(currentUserId, service, t))
-                .orElseGet(() -> draftRepo.readAll(currentUserId, service));
+            params.isEmpty()
+                ? draftRepo.readAll(currentUserId, service)
+                : draftRepo.readAll(currentUserId, service, params);
 
         return new DraftList(drafts);
     }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/exception/DraftStoreException.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/exception/DraftStoreException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.draftstore.exception;
+
+public class DraftStoreException extends RuntimeException {
+    public DraftStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/db/migration/V7__use_jsonb_type.sql
+++ b/src/main/resources/db/migration/V7__use_jsonb_type.sql
@@ -1,0 +1,4 @@
+ALTER TABLE draft_document
+ALTER COLUMN document
+SET DATA TYPE jsonb
+USING document::jsonb;


### PR DESCRIPTION
### Change description ###

Allows simple filtering by json document content using query params.  
For example:
```
/drafts?colour=red&size=large
```
Only string properties are supported.  

There was an endpoint previously that allowed filtering only by type (`/drafts?type=xxx`) which checked special 'type' column, it is no longer supported.    
The same functionality can be now achieved by adding 'type' field to actual json document.


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes (v3 only)
[ ] No
```
