### PR TITLE
Optional draft encryption

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
@@ -9,14 +9,13 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.hmcts.reform.draftstore.domain.Draft;
+import uk.gov.hmcts.reform.draftstore.data.model.Draft;
 import uk.gov.hmcts.reform.draftstore.domain.SaveStatus;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 
 import java.sql.SQLException;
 import java.util.List;
 
-import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.draftstore.domain.SaveStatus.Created;
 import static uk.gov.hmcts.reform.draftstore.domain.SaveStatus.Updated;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/PaginationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/PaginationTest.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.gov.hmcts.reform.draftstore.domain.Draft;
+import uk.gov.hmcts.reform.draftstore.data.model.Draft;
 import uk.gov.hmcts.reform.draftstore.endpoint.v3.helpers.SampleData;
 
 import java.util.List;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/CreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/CreateTest.java
@@ -85,7 +85,7 @@ public class CreateTest {
 
     private ResultActions send(String content) throws Exception {
         BDDMockito
-            .given(authService.authenticate(anyString(), anyString()))
+            .given(authService.authenticate(anyString(), anyString(), anyString()))
             .willReturn(new UserAndService("john", "service"));
 
         return mockMvc

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
@@ -54,7 +54,7 @@ public class UpdateTest {
 
     @Test
     public void should_return_400_when_secret_is_not_long_enough() throws Exception {
-        sendUpdate(Strings.repeat("x", MIN_SECRET_LENGTH)).andExpect(status().isNoContent());
+        sendUpdate(Strings.repeat("x", MIN_SECRET_LENGTH - 1)).andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/UpdateTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.draftstore.endpoint.v3;
 
+import com.google.common.base.Strings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import uk.gov.hmcts.reform.draftstore.domain.UpdateDraft;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
@@ -22,6 +24,8 @@ import static org.mockito.Matchers.anyString;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.draftstore.endpoint.v3.DraftController.MIN_SECRET_LENGTH;
+import static uk.gov.hmcts.reform.draftstore.service.AuthService.SECRET_HEADER;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SERVICE_HEADER;
 
 @RunWith(SpringRunner.class)
@@ -49,6 +53,11 @@ public class UpdateTest {
     }
 
     @Test
+    public void should_return_400_when_secret_is_not_long_enough() throws Exception {
+        sendUpdate(Strings.repeat("x", MIN_SECRET_LENGTH)).andExpect(status().isNoContent());
+    }
+
+    @Test
     public void should_return_404_when_no_draft_found_exception_is_thrown() throws Exception {
         willThrow(new NoDraftFoundException())
             .given(draftService)
@@ -58,13 +67,17 @@ public class UpdateTest {
     }
 
     private ResultActions sendUpdate() throws Exception {
-        return mockMvc
-            .perform(
-                put("/drafts/123")
-                    .header(AUTHORIZATION, "abc")
-                    .header(SERVICE_HEADER, "xyz")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content("{ \"type\": \"some_type\", \"document\": {\"a\":\"b\"} }")
-            );
+        return sendUpdate(null);
+    }
+
+    private ResultActions sendUpdate(String secret) throws Exception {
+        MockHttpServletRequestBuilder request =
+            put("/drafts/123")
+                .header(AUTHORIZATION, "abc")
+                .header(SERVICE_HEADER, "xyz")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ \"type\": \"some_type\", \"document\": {\"a\":\"b\"} }");
+
+        return mockMvc.perform(secret == null ? request : request.header(SECRET_HEADER, secret));
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/helpers/SampleData.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/helpers/SampleData.java
@@ -1,9 +1,8 @@
 package uk.gov.hmcts.reform.draftstore.endpoint.v3.helpers;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import uk.gov.hmcts.reform.draftstore.domain.CreateDraft;
-import uk.gov.hmcts.reform.draftstore.domain.Draft;
-import uk.gov.hmcts.reform.draftstore.domain.UpdateDraft;
+import uk.gov.hmcts.reform.draftstore.data.model.CreateDraft;
+import uk.gov.hmcts.reform.draftstore.data.model.Draft;
+import uk.gov.hmcts.reform.draftstore.data.model.UpdateDraft;
 
 import java.time.ZonedDateTime;
 
@@ -14,6 +13,7 @@ public class SampleData {
             "abc",
             "serviceA",
             "{}",
+            null,
             "some_type",
             ZonedDateTime.now(),
             ZonedDateTime.now()
@@ -21,12 +21,13 @@ public class SampleData {
     }
 
     public static UpdateDraft updateDraft() {
-        return new UpdateDraft(new ObjectMapper().createObjectNode(), "some_type");
+        return new UpdateDraft("{}", null, "some_type");
     }
 
     public static CreateDraft createDraft(int maxStaleDays) {
         return new CreateDraft(
-            new ObjectMapper().createObjectNode(),
+            "{}",
+            null,
             "some_type",
             maxStaleDays
         );

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/model/CreateDraft.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/model/CreateDraft.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.draftstore.data.model;
+
+public class CreateDraft {
+
+    public final String document;
+    public final byte[] encryptedDocument;
+    public final String type;
+    public final Integer maxStaleDays;
+
+    // region constructor
+    public CreateDraft(String document, byte[] encryptedDocument, String type, Integer maxStaleDays) {
+        this.document = document;
+        this.encryptedDocument = encryptedDocument;
+        this.type = type;
+        this.maxStaleDays = maxStaleDays;
+    }
+    // endregion
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/model/Draft.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/model/Draft.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.draftstore.data.model;
+
+import java.time.ZonedDateTime;
+
+public class Draft {
+
+    public final String id;
+    public final String userId;
+    public final String service;
+    public final String document;
+    public final byte[] encryptedDocument;
+    public final String type;
+    public final ZonedDateTime created;
+    public final ZonedDateTime updated;
+
+    // region constructor
+
+    public Draft(
+        String id,
+        String userId,
+        String service,
+        String document,
+        byte[] encryptedDocument,
+        String type,
+        ZonedDateTime created,
+        ZonedDateTime updated
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.service = service;
+        this.document = document;
+        this.encryptedDocument = encryptedDocument;
+        this.type = type;
+        this.created = created;
+        this.updated = updated;
+    }
+
+    // endregion
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/model/UpdateDraft.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/model/UpdateDraft.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.draftstore.data.model;
+
+public class UpdateDraft {
+
+    public final String document;
+    public final byte[] encryptedDocument;
+    public final String type;
+
+    // region constructor
+    public UpdateDraft(
+        String document,
+        byte[] encryptedDocument,
+        String type
+    ) {
+        this.document = document;
+        this.encryptedDocument = encryptedDocument;
+        this.type = type;
+    }
+    // endregion
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/EndpointExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/EndpointExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import uk.gov.hmcts.reform.draftstore.endpoint.domain.ErrorResult;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
+import uk.gov.hmcts.reform.draftstore.service.crypto.InvalidKeyException;
 
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
@@ -119,6 +120,15 @@ public class EndpointExceptionHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(
             new ErrorResult(USER_DETAILS_SERVICE_ERROR, singletonList(exception.getMessage())),
             FORBIDDEN
+        );
+    }
+
+    @ExceptionHandler(InvalidKeyException.class)
+    public ResponseEntity<ErrorResult> cryptoException(HttpServletRequest req, Exception exception) {
+        log.warn(exception.getMessage(), exception);
+        return new ResponseEntity<>(
+            new ErrorResult(BAD_ARGUMENT, singletonList(exception.getMessage())),
+            BAD_REQUEST
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/EndpointExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/EndpointExceptionHandler.java
@@ -124,7 +124,7 @@ public class EndpointExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(InvalidKeyException.class)
-    public ResponseEntity<ErrorResult> cryptoException(HttpServletRequest req, Exception exception) {
+    public ResponseEntity<ErrorResult> invalidCryptoKey(HttpServletRequest req, Exception exception) {
         log.warn(exception.getMessage(), exception);
         return new ResponseEntity<>(
             new ErrorResult(BAD_ARGUMENT, singletonList(exception.getMessage())),

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/endpoint/v3/DraftController.java
@@ -43,7 +43,9 @@ import static uk.gov.hmcts.reform.draftstore.service.AuthService.SERVICE_HEADER;
     path = "drafts",
     produces = MediaType.APPLICATION_JSON_VALUE
 )
+@SuppressWarnings("checkstyle:LineLength")
 public class DraftController {
+    public static final int MIN_SECRET_LENGTH = 16;
 
     private final AuthService authService;
     private final DraftService draftService;
@@ -93,7 +95,7 @@ public class DraftController {
     public ResponseEntity<Void> create(
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestHeader(SERVICE_HEADER) String serviceHeader,
-        @RequestHeader(name = SECRET_HEADER, required = false) @Valid @Length(min = 16) String secretHeader,
+        @RequestHeader(name = SECRET_HEADER, required = false) @Valid @Length(min = MIN_SECRET_LENGTH) String secretHeader,
         @RequestBody @Valid CreateDraft newDraft
     ) {
         UserAndService userAndService = authService.authenticate(authHeader, serviceHeader, secretHeader);
@@ -115,7 +117,7 @@ public class DraftController {
         @PathVariable String id,
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestHeader(SERVICE_HEADER) String serviceHeader,
-        @RequestHeader(name = SECRET_HEADER, required = false) @Valid @Length(min = 16) String secretHeader,
+        @RequestHeader(name = SECRET_HEADER, required = false) @Valid @Length(min = MIN_SECRET_LENGTH) String secretHeader,
         @RequestBody @Valid UpdateDraft updatedDraft
     ) {
         UserAndService userAndService = authService.authenticate(authHeader, serviceHeader, secretHeader);

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/AuthService.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/AuthService.java
@@ -12,6 +12,7 @@ import javax.validation.constraints.NotNull;
 public class AuthService {
 
     public static final String SERVICE_HEADER = "ServiceAuthorization";
+    public static final String SECRET_HEADER = "Secret";
     public static final String AUTH_TYPE = "hmcts-id ";
 
     private final IdamClient idamClient;
@@ -36,10 +37,11 @@ public class AuthService {
         );
     }
 
-    public UserAndService authenticate(String userHeader, String serviceHeader) {
+    public UserAndService authenticate(String userHeader, String serviceHeader, String secretHeader) {
         return new UserAndService(
             idamClient.getUserDetails(userHeader).id,
-            s2sClient.getServiceName(serviceHeader)
+            s2sClient.getServiceName(serviceHeader),
+            secretHeader
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/UserAndService.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/UserAndService.java
@@ -4,9 +4,15 @@ public class UserAndService {
 
     public final String userId;
     public final String service;
+    public final String secret;
 
-    public UserAndService(String userId, String service) {
+    public UserAndService(String userId, String service, String secret) {
         this.userId = userId;
         this.service = service;
+        this.secret = secret;
+    }
+
+    public UserAndService(String userId, String service) {
+        this(userId, service, null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/crypto/CryptoService.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/crypto/CryptoService.java
@@ -9,6 +9,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
@@ -64,6 +65,8 @@ public class CryptoService {
 
             return new String(cipher.doFinal(cipherText), UTF_8);
 
+        } catch (AEADBadTagException exc) {
+            throw new InvalidKeyException("Invalid secret");
         } catch (GeneralSecurityException exc) {
             throw new GeneralSecurityRuntimeException(exc);
         }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/crypto/InvalidKeyException.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/crypto/InvalidKeyException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.draftstore.service.crypto;
+
+public class InvalidKeyException extends RuntimeException {
+
+    public InvalidKeyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/mappers/FromDbModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/mappers/FromDbModelMapper.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.draftstore.service.mappers;
+
+import uk.gov.hmcts.reform.draftstore.domain.Draft;
+import uk.gov.hmcts.reform.draftstore.service.crypto.CryptoService;
+
+public class FromDbModelMapper {
+
+    public static Draft fromDb(
+        uk.gov.hmcts.reform.draftstore.data.model.Draft dbDraft,
+        String secret
+    ) {
+        // only during transition stage
+        String documentToReturn =
+            dbDraft.encryptedDocument == null
+                ? dbDraft.document
+                : CryptoService.decrypt(dbDraft.encryptedDocument, secret);
+
+        return new Draft(
+            dbDraft.id,
+            dbDraft.userId,
+            dbDraft.service,
+            documentToReturn,
+            dbDraft.type,
+            dbDraft.created,
+            dbDraft.updated
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapper.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.draftstore.service.mappers;
 import uk.gov.hmcts.reform.draftstore.data.model.CreateDraft;
 import uk.gov.hmcts.reform.draftstore.data.model.UpdateDraft;
 
-import java.util.function.Supplier;
-
 import static uk.gov.hmcts.reform.draftstore.service.crypto.CryptoService.encrypt;
 
 public class ToDbModelMapper {
@@ -13,11 +11,9 @@ public class ToDbModelMapper {
         uk.gov.hmcts.reform.draftstore.domain.CreateDraft draft,
         String secret
     ) {
-        Docs docs = getDocuments(secret, () -> draft.document.toString());
-
         return new CreateDraft(
-            docs.plainText,
-            docs.encrypted,
+            secret == null ? draft.document.toString() : null,
+            secret == null ? null : encrypt(draft.document.toString(), secret),
             draft.type,
             draft.maxStaleDays
         );
@@ -27,28 +23,10 @@ public class ToDbModelMapper {
         uk.gov.hmcts.reform.draftstore.domain.UpdateDraft draft,
         String secret
     ) {
-        Docs docs = getDocuments(secret, () -> draft.document.toString());
-
         return new UpdateDraft(
-            docs.plainText,
-            docs.encrypted,
+            secret == null ? draft.document.toString() : null,
+            secret == null ? null : encrypt(draft.document.toString(), secret),
             draft.type
         );
-    }
-
-    private static Docs getDocuments(String secret, Supplier<String> inputDocument) {
-        return secret != null
-            ? new Docs(null, encrypt(inputDocument.get(), secret))
-            : new Docs(inputDocument.get(), null);
-    }
-
-    static class Docs {
-        String plainText;
-        byte[] encrypted;
-
-        public Docs(String plainText, byte[] encrypted) {
-            this.plainText = plainText;
-            this.encrypted = encrypted;
-        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapper.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.draftstore.service.mappers;
+
+import uk.gov.hmcts.reform.draftstore.data.model.CreateDraft;
+import uk.gov.hmcts.reform.draftstore.data.model.UpdateDraft;
+
+import java.util.function.Supplier;
+
+import static uk.gov.hmcts.reform.draftstore.service.crypto.CryptoService.encrypt;
+
+public class ToDbModelMapper {
+
+    public static CreateDraft toDb(
+        uk.gov.hmcts.reform.draftstore.domain.CreateDraft draft,
+        String secret
+    ) {
+        Docs docs = getDocuments(secret, () -> draft.document.toString());
+
+        return new CreateDraft(
+            docs.plainText,
+            docs.encrypted,
+            draft.type,
+            draft.maxStaleDays
+        );
+    }
+
+    public static UpdateDraft toDb(
+        uk.gov.hmcts.reform.draftstore.domain.UpdateDraft draft,
+        String secret
+    ) {
+        Docs docs = getDocuments(secret, () -> draft.document.toString());
+
+        return new UpdateDraft(
+            docs.plainText,
+            docs.encrypted,
+            draft.type
+        );
+    }
+
+    private static Docs getDocuments(String secret, Supplier<String> inputDocument) {
+        return secret != null
+            ? new Docs(null, encrypt(inputDocument.get(), secret))
+            : new Docs(inputDocument.get(), null);
+    }
+
+    static class Docs {
+        String plainText;
+        byte[] encrypted;
+
+        public Docs(String plainText, byte[] encrypted) {
+            this.plainText = plainText;
+            this.encrypted = encrypted;
+        }
+    }
+}

--- a/src/main/resources/db/migration/V8__add_encrypted_doc_column.sql
+++ b/src/main/resources/db/migration/V8__add_encrypted_doc_column.sql
@@ -1,0 +1,6 @@
+-- during the transition stage both columns will be nullable
+ALTER TABLE draft_document
+ADD COLUMN encrypted_document BYTEA NULL;
+
+ALTER TABLE draft_document
+ALTER COLUMN document DROP NOT NULL;

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/crypto/CryptoServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/crypto/CryptoServiceTest.java
@@ -42,7 +42,6 @@ public class CryptoServiceTest {
 
         // then
         assertThat(thrown)
-            .isInstanceOf(GeneralSecurityRuntimeException.class)
-            .hasCauseInstanceOf(AEADBadTagException.class);
+            .isInstanceOf(InvalidKeyException.class);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/draftservice/BaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/draftservice/BaseTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
-import uk.gov.hmcts.reform.draftstore.domain.Draft;
+import uk.gov.hmcts.reform.draftstore.data.model.Draft;
 import uk.gov.hmcts.reform.draftstore.service.DraftService;
 import uk.gov.hmcts.reform.draftstore.service.UserAndService;
 
@@ -29,6 +29,7 @@ public class BaseTest {
             userAndService.userId,
             userAndService.service,
             "{}",
+            null,
             "some_type",
             ZonedDateTime.now(),
             ZonedDateTime.now()

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/FromDbModelMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/FromDbModelMapperTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.draftstore.service.mappers;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.draftstore.data.model.Draft;
+import uk.gov.hmcts.reform.draftstore.service.crypto.CryptoService;
+
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FromDbModelMapperTest {
+
+    private uk.gov.hmcts.reform.draftstore.domain.Draft result;
+
+    @Test
+    public void should_use_plaintext_document_when_it_was_not_encrypted() throws Exception {
+
+        result = FromDbModelMapper
+            .fromDb(
+                dbDraft("hello", null),
+                "not used secret"
+            );
+
+        assertThat(result.document).isEqualTo("hello");
+    }
+
+    @Test
+    public void should_use_encrypted_document_when_it_is_encrypted() throws Exception {
+
+        result = FromDbModelMapper
+            .fromDb(
+                dbDraft(null, CryptoService.encrypt("hello", "secret")),
+                "secret"
+            );
+
+        assertThat(result.document).isEqualTo("hello");
+    }
+
+    private Draft dbDraft(String plaintextDoc, byte[] encryptedDoc) {
+        return new Draft(
+            "id",
+            "user",
+            "service",
+            plaintextDoc,
+            encryptedDoc,
+            "type",
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/FromDbModelMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/FromDbModelMapperTest.java
@@ -13,7 +13,7 @@ public class FromDbModelMapperTest {
     private uk.gov.hmcts.reform.draftstore.domain.Draft result;
 
     @Test
-    public void should_use_plaintext_document_when_it_was_not_encrypted() throws Exception {
+    public void should_use_plaintext_document_if_it_was_not_encrypted() throws Exception {
 
         result = FromDbModelMapper
             .fromDb(
@@ -25,7 +25,7 @@ public class FromDbModelMapperTest {
     }
 
     @Test
-    public void should_use_encrypted_document_when_it_is_encrypted() throws Exception {
+    public void should_use_encrypted_document_when_it_is_available() throws Exception {
 
         result = FromDbModelMapper
             .fromDb(

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapperTest.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.draftstore.service.mappers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.hmcts.reform.draftstore.domain.CreateDraft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ToDbModelMapperTest {
+
+    private uk.gov.hmcts.reform.draftstore.data.model.CreateDraft result;
+
+    @Test
+    public void should_set_only_encrypted_document_when_secret_is_passed() throws Exception {
+         result = ToDbModelMapper.toDb(createDraft(), "a98sdf8asd7f");
+
+         assertThat(result.document).isNull();
+         assertThat(result.encryptedDocument).isNotNull();
+    }
+
+    @Test
+    public void should_set_only_unencrypted_document_when_secret_is_NOT_passed() throws Exception {
+        result = ToDbModelMapper.toDb(createDraft(), null);
+
+        assertThat(result.document).isNotNull();
+        assertThat(result.encryptedDocument).isNull();
+    }
+
+    private CreateDraft createDraft() {
+        return new CreateDraft(
+            new ObjectMapper().createObjectNode(),
+            "type",
+            123
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapperTest.java
@@ -12,10 +12,10 @@ public class ToDbModelMapperTest {
 
     @Test
     public void should_set_only_encrypted_document_when_secret_is_passed() throws Exception {
-         result = ToDbModelMapper.toDb(createDraft(), "a98sdf8asd7f");
+        result = ToDbModelMapper.toDb(createDraft(), "a98sdf8asd7f");
 
-         assertThat(result.document).isNull();
-         assertThat(result.encryptedDocument).isNotNull();
+        assertThat(result.document).isNull();
+        assertThat(result.encryptedDocument).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

Makes it possible to draft-store clients to encrypt drafts.

As it is not mandatory during the transitions stage, database now has two columns
to store draft (in either plaintext or encrypted form) but only one column is
being populated:

For write operations, if header containg secret is set, document is encrypted
before storing in db using key derived from provided secret.

For read operations, if db row contains encrypted document, secret sent by the clients
will be used to decrypt the document.


Added a new set of models to be used by repository layer. Those models contain
data for both columns, repo just stores/retrieves the data.
The data transformation is handled by the service layer (added recently).
