### PR TITLE
Add simple gatling performance test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 build
+classes/
 .DS_store
 .gradle
 out/

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ plugins {
   id 'org.sonarqube' version '2.5'
   id 'jacoco'
   id 'pmd'
+  id 'scala'
+  id 'com.github.lkishalmi.gatling' version '0.7.1'
 }
 
 group 'uk.gov.hmcts.reform'
@@ -79,6 +81,8 @@ dependencies {
   compile group: 'org.hibernate', name: 'hibernate-validator', version: '5.4.1.Final'
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '1.2.1'
+
+  compile 'org.scala-lang:scala-library:2.11.8'
 
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot

--- a/src/gatling/resources/conf/application.conf
+++ b/src/gatling/resources/conf/application.conf
@@ -1,0 +1,2 @@
+baseUrl = "http://localhost:8800/drafts"
+baseUrl = ${?DRAFT_STORE_BASE_URL}

--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/CreateMultipleDrafts.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/CreateMultipleDrafts.scala
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.draftstore
+
+import com.typesafe.config.ConfigFactory
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import uk.gov.hmcts.reform.draftstore.actions.Create.create
+import uk.gov.hmcts.reform.draftstore.actions.ReadOne.readOne
+
+import scala.concurrent.duration._
+
+class CreateMultipleDrafts extends Simulation {
+
+  val config = ConfigFactory.load()
+
+  val httpProtocol =
+    http
+      .baseURL(config.getString("baseUrl"))
+      .contentTypeHeader("application/json")
+      .headers(Map(
+        "Authorization" -> "123",
+        "ServiceAuthorization" -> "some_service"
+      ))
+
+  val scn =
+    scenario("Create multiple drafts")
+      .during(1.minute)(
+        exec(
+          create,
+          readOne,
+          pause(2.seconds)
+        )
+      )
+
+  setUp(scn.inject(rampUsers(100).over(5.seconds))).protocols(httpProtocol)
+}

--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/Create.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/Create.scala
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.draftstore.actions
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import io.gatling.http.Predef._
+
+object Create {
+
+  val create: ChainBuilder =
+    exec(
+      http("Create draft")
+        .post(url = "")
+        .body(
+          StringBody(
+            """
+              |{
+              |  "document": {
+              |    "a": "some value",
+              |    "b": "some other value",
+              |    "c": "yet another",
+              |    "nested": {
+              |      "xxx": "yyy"
+              |    }
+              |  },
+              |  "type": "my type"
+              |}
+            """.stripMargin
+          )
+        )
+        .check(headerRegex("Location", """/(\d+)$""").saveAs("id"))
+    )
+}

--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/ReadOne.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/ReadOne.scala
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.draftstore.actions
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import io.gatling.http.Predef._
+
+object ReadOne {
+
+  val readOne: ChainBuilder =
+    exec(
+      http("Read created draft")
+        .get(url = "/${id}")
+    )
+}


### PR DESCRIPTION
### Change description ###

Added simple gatling test.  
Requires draft-store to use stub idam and s2s clients.

To do in next pull requests:
- add more tests
- handle idam
- handle s2s

To run locally:
```bash
./gradlew gatlingRun-uk.gov.hmcts.reform.draftstore.CreateMultipleDrafts
```

Results on my machine (response time in ms):

_ | Min | 50th pct | 75th pct | 95th pct | 99th pct | Max | Mean | Std De
-- | -- | -- | -- | -- | -- | -- | -- | --
create | 2 | 5 | 6 | 11 | 27 | 102 | 6 | 5
read | 1 | 2 | 3 | 5 | 9 | 143 | 3 | 4
