### PR TITLE
Use s2s tokens in gatling tests

### DIFF
--- a/src/gatling/resources/conf/application.conf
+++ b/src/gatling/resources/conf/application.conf
@@ -1,2 +1,9 @@
 baseUrl = "http://localhost:8800/drafts"
 baseUrl = ${?DRAFT_STORE_BASE_URL}
+
+auth {
+  s2s {
+    leaseUrl = "http://localhost:8081/testing-support/lease"
+    leaseUrl = ${?S2S_LEASE_URL}
+  }
+}

--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/CreateMultipleDrafts.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/CreateMultipleDrafts.scala
@@ -5,6 +5,7 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import uk.gov.hmcts.reform.draftstore.actions.Create.create
 import uk.gov.hmcts.reform.draftstore.actions.ReadOne.readOne
+import uk.gov.hmcts.reform.draftstore.actions.setup.LeaseServiceToken.leaseServiceToken
 
 import scala.concurrent.duration._
 
@@ -17,12 +18,12 @@ class CreateMultipleDrafts extends Simulation {
       .baseURL(config.getString("baseUrl"))
       .contentTypeHeader("application/json")
       .headers(Map(
-        "Authorization" -> "123",
-        "ServiceAuthorization" -> "some_service"
+        "Authorization" -> "123"
       ))
 
   val scn =
     scenario("Create multiple drafts")
+      .exec(leaseServiceToken())
       .during(1.minute)(
         exec(
           create,

--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/Create.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/Create.scala
@@ -10,6 +10,7 @@ object Create {
     exec(
       http("Create draft")
         .post(url = "")
+        .header("ServiceAuthorization", "Bearer ${service_token}")
         .body(
           StringBody(
             """

--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/ReadOne.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/ReadOne.scala
@@ -10,5 +10,6 @@ object ReadOne {
     exec(
       http("Read created draft")
         .get(url = "/${id}")
+        .header("ServiceAuthorization", "Bearer ${service_token}")
     )
 }

--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/setup/LeaseServiceToken.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/setup/LeaseServiceToken.scala
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.draftstore.actions.setup
+
+import com.typesafe.config.ConfigFactory
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import io.gatling.http.HeaderNames._
+import io.gatling.http.HeaderValues._
+import io.gatling.http.Predef._
+
+import scala.util.Random
+
+object LeaseServiceToken {
+
+  private val url = ConfigFactory.load().getString("auth.s2s.leaseUrl")
+
+  /**
+    * Calls S2S service to retrieve service token later used in auth headers sent to draft-store
+    */
+  def leaseServiceToken(): ChainBuilder =
+    exec(
+      http("Lease service token")
+        .post(url)
+        .header(ContentType, ApplicationFormUrlEncoded)
+        .formParam("microservice", generateRandomServiceName())
+        .check(bodyString.saveAs("service_token"))
+    )
+
+  private def generateRandomServiceName(): String = {
+    s"some_service_${Random.nextInt(Integer.MAX_VALUE)}"
+  }
+}


### PR DESCRIPTION
### Change description ###

Retrieve s2s service token for each user in setup stage using `/testing-support` endpoint.

Property `auth.provider.service.testing-support.enabled` has to be set to `true` on s2s service.