### PR TITLE
Use random s2s service names in gatling tests

### DIFF
--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/CreateMultipleDrafts.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/CreateMultipleDrafts.scala
@@ -23,7 +23,7 @@ class CreateMultipleDrafts extends Simulation {
 
   val scn =
     scenario("Create multiple drafts")
-      .exec(leaseServiceToken())
+      .exec(leaseServiceToken)
       .during(1.minute)(
         exec(
           create,

--- a/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/setup/LeaseServiceToken.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/draftstore/actions/setup/LeaseServiceToken.scala
@@ -13,19 +13,19 @@ object LeaseServiceToken {
 
   private val url = ConfigFactory.load().getString("auth.s2s.leaseUrl")
 
+  private val serviceNameFeeder =
+    Iterator.continually(Map("service_name" -> ("service_" + Random.nextInt(10))))
+
   /**
     * Calls S2S service to retrieve service token later used in auth headers sent to draft-store
     */
-  def leaseServiceToken(): ChainBuilder =
-    exec(
-      http("Lease service token")
-        .post(url)
-        .header(ContentType, ApplicationFormUrlEncoded)
-        .formParam("microservice", generateRandomServiceName())
-        .check(bodyString.saveAs("service_token"))
-    )
-
-  private def generateRandomServiceName(): String = {
-    s"some_service_${Random.nextInt(Integer.MAX_VALUE)}"
-  }
+  val leaseServiceToken: ChainBuilder =
+    feed(serviceNameFeeder)
+      .exec(
+        http("Lease service token")
+          .post(url)
+          .header(ContentType, ApplicationFormUrlEncoded)
+          .formParam("microservice", "${service_name}")
+          .check(bodyString.saveAs("service_token"))
+      )
 }


### PR DESCRIPTION
### Change description ###
Previous implementation actually called method once resulting in using the same one random service name for all concurrent users.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
