### PR TITLE
Use TestContainers to run functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: required
 language: java
-services:
-  - docker
 jdk:
   - oraclejdk8
 os:
@@ -16,10 +14,8 @@ cache:
 before_install:
   - sudo apt-get install jq
   - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
-  - docker-compose build draft-store-database
-  - docker-compose up -d draft-store-database
 script:
-  - ./gradlew build
+  - ./gradlew build -x
   - ./gradlew test
   - ./gradlew functionalTest
   - ./gradlew jacocoTestReport

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo apt-get install jq
   - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
 script:
-  - ./gradlew build -x
+  - ./gradlew build
   - ./gradlew test
   - ./gradlew functionalTest
   - ./gradlew jacocoTestReport

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,12 @@ node {
       }
     }
 
-    stage('Test (Unit)') {
+    stage('Test (unit)') {
       sh "./gradlew test"
+    }
+
+    stage('Test (functional)') {
+      sh "./gradlew functionalTest"
     }
 
     stage('Package (JAR)') {

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ To run all unit tests execute the following command:
 ./gradlew test
 ```
 
+### Functional tests
+To run all functional tests execute the following command:
+```bash
+./gradlew functionalTest
+```
+
 ### Coding style tests
 To run all checks (including unit tests) execute the following command:
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,6 @@ dependencies {
 
   compile group: 'uk.gov.hmcts.reform', name: 'reform-api-standards', version: '0.2.1'
 
-
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
   functionalTestCompile sourceSets.main.runtimeClasspath
@@ -97,7 +96,8 @@ dependencies {
     'com.jayway.restassured:rest-assured:2.9.0',
     'org.mockito:mockito-core:1.10.19',
     'org.assertj:assertj-core:3.6.2',
-    'com.github.tomakehurst:wiremock:2.5.1')
+    'com.github.tomakehurst:wiremock:2.5.1',
+    'org.testcontainers:postgresql:1.4.3')
 
 }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAOTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.draftstore.data.model.Draft;
@@ -23,6 +24,7 @@ import static uk.gov.hmcts.reform.draftstore.domain.SaveStatus.Updated;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource("/database.properties")
 @Transactional
 public class DraftStoreDAOTest {
     private static final String USER_ID = "a user";

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/OldDraftsCleanupTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/OldDraftsCleanupTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.hmcts.reform.draftstore.endpoint.v3.helpers.SampleData;
 
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest
+@TestPropertySource("/database.properties")
 @ActiveProfiles("test")
 public class OldDraftsCleanupTest {
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/PaginationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/data/PaginationTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.hmcts.reform.draftstore.data.model.Draft;
 import uk.gov.hmcts.reform.draftstore.endpoint.v3.helpers.SampleData;
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest
+@TestPropertySource("/database.properties")
 @ActiveProfiles("test")
 public class PaginationTest {
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/AbstractDraftStoreEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/AbstractDraftStoreEndpointTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.draftstore.data.DataAgent;
 
@@ -27,6 +28,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource("/database.properties")
 @ActiveProfiles("test")
 public abstract class AbstractDraftStoreEndpointTest {
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/HandleUnknownExceptionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/endpoint/HandleUnknownExceptionTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
 
@@ -29,6 +30,7 @@ So, this test demonstrates that for all unhandled exceptions the exception messa
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource("/database.properties")
 @ActiveProfiles("test-unhandled-exception")
 public class HandleUnknownExceptionTest {
     private static final String DRAFT_URI = "/drafts";

--- a/src/functionalTest/resources/database.properties
+++ b/src/functionalTest/resources/database.properties
@@ -1,0 +1,2 @@
+spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
+spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/draftstore


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Change introduces TestContainers to start database instance in docker environment prior to run functional tests. That should simplify development process by not requiring database to be 'up and running'  when functional tests are run.

TestContainers doc: https://www.testcontainers.org/usage/database_containers.html#benefits

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```