### PR TITLE
Fix publish swagger ci build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 language: java
+services:
+  - docker
 jdk:
   - oraclejdk8
 os:

--- a/publish-swagger-docs.sh
+++ b/publish-swagger-docs.sh
@@ -9,7 +9,7 @@ then
 fi
 
 docker-compose up -d
-sleep 10
+sleep 15
 REPO_NAME=$(echo ${TRAVIS_REPO_SLUG} | cut -f2- -d/)
 CURRENT_DOCS=$(curl https://hmcts.github.io/reform-api-docs/specs/${REPO_NAME}.json)
 NEW_DOCS=$(curl http://localhost:8800/v2/api-docs)


### PR DESCRIPTION
Bring back docker to travis (removed in https://github.com/hmcts/draft-store/pull/66) and increase sleep time
