### PR TITLE
Add warning header to response if encryption is not used when creating/updating drafts

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/CreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/CreateTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.HttpHeaders.WARNING;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SECRET_HEADER;
@@ -94,6 +95,28 @@ public class CreateTest {
         MvcResult result = send("{ \"type\": \"some_type\", \"document\": {\"a\":\"b\"} }").andReturn();
 
         assertThat(result.getResponse().getHeader(LOCATION)).endsWith("/drafts/" + newClaimId);
+    }
+
+    @Test
+    public void should_add_warning_header_when_encryption_secret_is_not_provided() throws Exception {
+        MvcResult result = send("{ \"type\": \"some_type\", \"document\": {\"a\":\"b\"} }", null).andReturn();
+
+        assertThat(result.getResponse().getHeader(WARNING))
+            .as("Warning header")
+            .isNotBlank();
+    }
+
+    @Test
+    public void should_NOT_add_warning_header_when_encryption_secret_is_not_provided() throws Exception {
+        MvcResult result =
+            send(
+                "{ \"type\": \"some_type\", \"document\": {\"a\":\"b\"} }",
+                Strings.repeat("x", MIN_SECRET_LENGTH)
+            ).andReturn();
+
+        assertThat(result.getResponse().getHeader(WARNING))
+            .as("Warning header")
+            .isNull();
     }
 
     private ResultActions send(String content) throws Exception {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/CreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/CreateTest.java
@@ -109,7 +109,7 @@ public class CreateTest {
     }
 
     @Test
-    public void should_NOT_add_warning_header_when_encryption_secret_is_not_provided() throws Exception {
+    public void should_NOT_add_warning_header_when_encryption_secret_is_provided() throws Exception {
         MvcResult result =
             send(
                 validDraft,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/UpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/UpdateTest.java
@@ -4,7 +4,6 @@ import com.google.common.base.Strings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
-import org.mockito.internal.matchers.Null;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -21,11 +20,11 @@ import uk.gov.hmcts.reform.draftstore.service.AuthService;
 import uk.gov.hmcts.reform.draftstore.service.DraftService;
 import uk.gov.hmcts.reform.draftstore.service.UserAndService;
 
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.internal.matchers.Null.*;
+import static org.mockito.internal.matchers.Null.NULL;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.WARNING;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -74,15 +73,14 @@ public class UpdateTest {
 
     @Test
     public void should_set_warning_header_when_encryption_header_is_not_provided() throws Exception {
-        sendUpdate()
-            .andExpect(header().string(WARNING, NULL));
+        sendUpdate(null)
+            .andExpect(header().string(WARNING, notNullValue()));
     }
 
     @Test
     public void should_NOT_set_warning_header_when_encryption_header_is_provided() throws Exception {
         sendUpdate(Strings.repeat("?", MIN_SECRET_LENGTH))
-            .andExpect(status().isBadRequest());
-
+            .andExpect(header().string(WARNING, NULL));
     }
 
     private ResultActions sendUpdate() throws Exception {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/UpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/UpdateTest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
+import org.mockito.internal.matchers.Null;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -23,8 +24,12 @@ import uk.gov.hmcts.reform.draftstore.service.UserAndService;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.internal.matchers.Null.*;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.WARNING;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SECRET_HEADER;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SERVICE_HEADER;
@@ -65,6 +70,19 @@ public class UpdateTest {
             .update(anyString(), any(UpdateDraft.class), any(UserAndService.class));
 
         sendUpdate().andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void should_set_warning_header_when_encryption_header_is_not_provided() throws Exception {
+        sendUpdate()
+            .andExpect(header().string(WARNING, NULL));
+    }
+
+    @Test
+    public void should_NOT_set_warning_header_when_encryption_header_is_provided() throws Exception {
+        sendUpdate(Strings.repeat("?", MIN_SECRET_LENGTH))
+            .andExpect(status().isBadRequest());
+
     }
 
     private ResultActions sendUpdate() throws Exception {


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
