### PR TITLE
Add info on unencrypted drafts

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDAO.java
@@ -16,6 +16,7 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 
@@ -128,6 +129,13 @@ public class DraftStoreDAO {
             "DELETE FROM draft_document "
                 + "WHERE updated + interval '1 day' * max_stale_days < :now",
             new MapSqlParameterSource("now", Timestamp.from(this.clock.instant()))
+        );
+    }
+
+    public List<Map<String, Object>> getUnencryptedDrafts() {
+        return jdbcTemplate.queryForList(
+            "SELECT service, created, updated FROM draft_document WHERE encrypted_document IS NULL",
+            new MapSqlParameterSource()
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
@@ -5,6 +5,7 @@ import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,15 +27,11 @@ public class UnencryptedDraftsInfoContributor implements InfoContributor {
 
     @Override
     public void contribute(Info.Builder builder) {
-        if (lastResult.isEmpty() || shouldRefresh()) {
+        if (lastCheckDate == null || Duration.between(lastCheckDate, now()).getSeconds() >= 60) {
             this.lastResult = repo.getUnencryptedDrafts();
             this.lastCheckDate = now();
         }
 
         builder.withDetail("unencrypted_drafts", this.lastResult);
-    }
-
-    private boolean shouldRefresh() {
-        return lastCheckDate == null || now().isAfter(lastCheckDate.plusMinutes(1));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.draftstore.info;
+
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
+
+@Component
+public class UnencryptedDraftsInfoContributor implements InfoContributor {
+
+    private final DraftStoreDAO repo;
+
+    public UnencryptedDraftsInfoContributor(DraftStoreDAO repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    public void contribute(Info.Builder builder) {
+        builder.withDetail("unecrypted_drafts", repo.getUnencryptedDrafts());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
@@ -5,10 +5,21 @@ import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.time.LocalDateTime.now;
+
 @Component
 public class UnencryptedDraftsInfoContributor implements InfoContributor {
 
     private final DraftStoreDAO repo;
+
+    private LocalDateTime lastCheckDate = null;
+    private List<Map<String, Object>> lastResult = new ArrayList<>();
 
     public UnencryptedDraftsInfoContributor(DraftStoreDAO repo) {
         this.repo = repo;
@@ -16,6 +27,18 @@ public class UnencryptedDraftsInfoContributor implements InfoContributor {
 
     @Override
     public void contribute(Info.Builder builder) {
-        builder.withDetail("unecrypted_drafts", repo.getUnencryptedDrafts());
+        if (lastResult.isEmpty() || shouldRefresh()) {
+            this.lastResult = repo.getUnencryptedDrafts();
+            this.lastCheckDate = now();
+        }
+
+        builder.withDetail("unencrypted_drafts", this.lastResult);
+    }
+
+    private boolean shouldRefresh() {
+        return Optional
+            .ofNullable(lastCheckDate)
+            .map(x -> x.plusMinutes(1).isBefore(now()))
+            .orElse(true);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
@@ -36,9 +36,6 @@ public class UnencryptedDraftsInfoContributor implements InfoContributor {
     }
 
     private boolean shouldRefresh() {
-        return Optional
-            .ofNullable(lastCheckDate)
-            .map(x -> x.plusMinutes(1).isBefore(now()))
-            .orElse(true);
+        return lastCheckDate == null || lastCheckDate.plusMinutes(1).isBefore(now());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/info/UnencryptedDraftsInfoContributor.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.time.LocalDateTime.now;
 
@@ -36,6 +35,6 @@ public class UnencryptedDraftsInfoContributor implements InfoContributor {
     }
 
     private boolean shouldRefresh() {
-        return lastCheckDate == null || lastCheckDate.plusMinutes(1).isBefore(now());
+        return lastCheckDate == null || now().isAfter(lastCheckDate.plusMinutes(1));
     }
 }


### PR DESCRIPTION
### Change description ###
Add info endpoint to check number of unencrypted drafts.

Sample response:
```
{
   "app":{
      "name":"HMCTS Draft Store"
   },
   "unecrypted_drafts":[
      {
         "service":"cmc",
         "created":"2017-11-13T15:43:48Z",
         "updated":"2017-11-13T15:43:48Z"
      },
      {
         "service":"cmc",
         "created":"2017-11-13T15:43:48Z",
         "updated":"2017-11-13T15:43:48Z"
      },
      {
         "service":"cmc",
         "created":"2017-11-13T15:44:08Z",
         "updated":"2017-11-13T15:44:08Z"
      }
   ]
}
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
