### PR TITLE
Add api standard version content-type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
@@ -95,7 +95,7 @@ public class DraftController {
         return draftService.read(userAndService.withSecrets(secrets), after, limit);
     }
 
-    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = { MEDIA_TYPE, MediaType.APPLICATION_JSON_VALUE })
     @ApiOperation("Create a new draft")
     @ApiResponses({
         @ApiResponse(code = 201, message = "Draft successfully created"),
@@ -117,7 +117,7 @@ public class DraftController {
         return withSecretsWarning(secrets, created(newClaimUri));
     }
 
-    @PutMapping(path = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(path = "/{id}", consumes = { MEDIA_TYPE, MediaType.APPLICATION_JSON_VALUE })
     @ApiOperation("Update existing draft")
     @ApiResponses({
         @ApiResponse(code = 204, message = "Draft updated"),

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
@@ -44,10 +44,12 @@ import static uk.gov.hmcts.reform.draftstore.service.secrets.Secrets.MIN_SECRET_
 @Validated
 @RequestMapping(
     path = "drafts",
-    produces = MediaType.APPLICATION_JSON_VALUE
+    produces = DraftController.MEDIA_TYPE
 )
 @SuppressWarnings("checkstyle:LineLength")
 public class DraftController {
+
+    static final String MEDIA_TYPE = "application/vnd.uk.gov.hmcts.draft-store+json;version=3";
 
     private final AuthService authService;
     private final DraftService draftService;

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
@@ -49,7 +49,7 @@ import static uk.gov.hmcts.reform.draftstore.service.secrets.Secrets.MIN_SECRET_
 @SuppressWarnings("checkstyle:LineLength")
 public class DraftController {
 
-    static final String MEDIA_TYPE = "application/vnd.uk.gov.hmcts.draft-store+json;version=3";
+    static final String MEDIA_TYPE = "application/vnd.uk.gov.hmcts.draft-store.v3+json";
 
     private final AuthService authService;
     private final DraftService draftService;

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
@@ -44,7 +44,7 @@ import static uk.gov.hmcts.reform.draftstore.service.secrets.Secrets.MIN_SECRET_
 @Validated
 @RequestMapping(
     path = "drafts",
-    produces = DraftController.MEDIA_TYPE
+    produces = { DraftController.MEDIA_TYPE, MediaType.APPLICATION_JSON_VALUE }
 )
 @SuppressWarnings("checkstyle:LineLength")
 public class DraftController {


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/RPE-108

### Change description ###
Added to handle versioning in the future. 
Current controllers handles both `application/json` and `application/vnd.uk.gov.hmcts.draft-store.v3+json`.
Any additional controllers will only handle specific version.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
