### PR TITLE
Fix swagger configuration

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/draftstore/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/config/SwaggerConfiguration.java
@@ -18,7 +18,7 @@ public class SwaggerConfiguration {
         return new Docket(DocumentationType.SWAGGER_2)
                 .useDefaultResponseMessages(false)
                 .select()
-                .apis(RequestHandlerSelectors.basePackage(DraftStoreApplication.BASE_PACKAGE_NAME + ".endpoint"))
+                .apis(RequestHandlerSelectors.basePackage(DraftStoreApplication.BASE_PACKAGE_NAME + ".controllers"))
                 .paths(PathSelectors.any())
                 .build();
     }


### PR DESCRIPTION
Broken by recent namespace changes.

Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
