### PR TITLE
Handle short fake auth headers in idam client stub

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientStub.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientStub.java
@@ -2,10 +2,13 @@ package uk.gov.hmcts.reform.draftstore.service.idam;
 
 public class IdamClientStub implements IdamClient {
 
-    private static final int MAX_USER_ID_LENGTH = 256; // enforced by database column
+    static final int MAX_USER_ID_LENGTH = 256; // enforced by database column
 
     @Override
     public User getUserDetails(String authHeader) {
-        return new User(authHeader.substring(0, MAX_USER_ID_LENGTH), "example@example.com");
+        String id = authHeader.substring(0, Math.min(authHeader.length(), MAX_USER_ID_LENGTH));
+        String email = "example@example.com";
+
+        return new User(id, email);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientStubTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientStubTest.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.draftstore.service.idam;
+
+import com.google.common.base.Strings;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IdamClientStubTest {
+
+    @Test
+    public void should_use_auth_header_as_user_id() throws Exception {
+        // given
+        IdamClientStub idamClientStub = new IdamClientStub();
+        String authHeader = "sample header";
+        // when
+        User user = idamClientStub.getUserDetails(authHeader);
+        // then
+        assertThat(user.id).isEqualTo(authHeader);
+    }
+
+    @Test
+    public void should_shorten_long_auth_headers_to_create_valid_user_id() throws Exception {
+        // given
+        IdamClientStub idamClientStub = new IdamClientStub();
+        String veryLongAuthHeader = Strings.repeat("x", IdamClientStub.MAX_USER_ID_LENGTH * 2);
+        // when
+        User user = idamClientStub.getUserDetails(veryLongAuthHeader);
+        // then
+        assertThat(user.id.length()).isEqualTo(IdamClientStub.MAX_USER_ID_LENGTH);
+    }
+}


### PR DESCRIPTION
**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```
