### PR TITLE
Make encryption mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ It stores a draft json document against the userId provided.
 
 ![Low Level Design](/docs/design.png)
 
-## Encryption feature in v3
-A new version of the API has been created to meet [point 6 of the NCSC Security Design Principles: Reducing the impact 
-of compromise](https://www.ncsc.gov.uk/guidance/design-principles-reducing-impact-compromise). 
-The current API allows for both client to _optionally_ supply an encryption key. This optionality will be revoked in the 
-future to ensure all partially completed form data being stored by service teams is encrypted per user.
- 
 ## Getting Started
 
 ### Prerequisites

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/HandleUnknownExceptionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/HandleUnknownExceptionTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.draftstore.controllers.helpers.SampleData;
 import uk.gov.hmcts.reform.draftstore.data.DraftStoreDAO;
 
 import java.util.UUID;
@@ -21,6 +22,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.draftstore.service.AuthService.SECRET_HEADER;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SERVICE_HEADER;
 
 /*
@@ -53,6 +55,7 @@ public class HandleUnknownExceptionTest {
             .accept(APPLICATION_JSON_VALUE)
             .header(AUTHORIZATION, AUTH_TOKEN)
             .header(SERVICE_HEADER, "some-service")
+            .header(SECRET_HEADER, SampleData.secret())
             .when()
             .get(DRAFT_URI)
             .then()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/CreateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/CreateTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import uk.gov.hmcts.reform.draftstore.controllers.DraftController;
+import uk.gov.hmcts.reform.draftstore.controllers.helpers.SampleData;
 import uk.gov.hmcts.reform.draftstore.domain.CreateDraft;
 import uk.gov.hmcts.reform.draftstore.service.AuthService;
 import uk.gov.hmcts.reform.draftstore.service.DraftService;
@@ -24,7 +25,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.LOCATION;
-import static org.springframework.http.HttpHeaders.WARNING;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SECRET_HEADER;
@@ -100,27 +100,12 @@ public class CreateTest {
     }
 
     @Test
-    public void should_add_warning_header_when_encryption_secret_is_not_provided() throws Exception {
-        MvcResult result = send(validDraft, null).andReturn();
-
-        assertThat(result.getResponse().getHeader(WARNING))
-            .as("Warning header")
-            .isNotBlank();
-    }
-
-    @Test
-    public void should_NOT_add_warning_header_when_encryption_secret_is_provided() throws Exception {
-        MvcResult result =
-            send(
-                validDraft,
-                Strings.repeat("x", MIN_SECRET_LENGTH)
-            ).andReturn();
-
-        assertThat(result.getResponse().getHeader(WARNING)).isNull();
+    public void should_return_400_when_encryption_secret_is_not_provided() throws Exception {
+        send(validDraft, null).andExpect(status().is(400));
     }
 
     private ResultActions send(String content) throws Exception {
-        return send(content, null);
+        return send(content, SampleData.secret());
     }
 
     private ResultActions send(String content, String secret) throws Exception {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/GetAllTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/GetAllTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.draftstore.controllers.DraftController;
+import uk.gov.hmcts.reform.draftstore.controllers.helpers.SampleData;
 import uk.gov.hmcts.reform.draftstore.domain.DraftList;
 import uk.gov.hmcts.reform.draftstore.service.AuthService;
 import uk.gov.hmcts.reform.draftstore.service.DraftService;
@@ -23,6 +24,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.draftstore.service.AuthService.SECRET_HEADER;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SERVICE_HEADER;
 
 @RunWith(SpringRunner.class)
@@ -50,6 +52,7 @@ public class GetAllTest {
                 get("/drafts?type=default")
                     .header(AUTHORIZATION, "auth-header-value")
                     .header(SERVICE_HEADER, "some_service_name")
+                    .header(SECRET_HEADER, SampleData.secret())
             )
             .andExpect(status().isOk())
             .andExpect(content().json("{ \"data\": [] }"));

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/GetByIdTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/GetByIdTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.draftstore.controllers.DraftController;
+import uk.gov.hmcts.reform.draftstore.controllers.helpers.SampleData;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 import uk.gov.hmcts.reform.draftstore.service.AuthService;
 import uk.gov.hmcts.reform.draftstore.service.DraftService;
@@ -21,6 +22,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static uk.gov.hmcts.reform.draftstore.service.AuthService.SECRET_HEADER;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SERVICE_HEADER;
 
 @RunWith(SpringRunner.class)
@@ -62,6 +64,7 @@ public class GetByIdTest {
                     get("/drafts/123")
                         .header(AUTHORIZATION, "irrelevant-header")
                         .header(SERVICE_HEADER, "irrelevant-service-name")
+                        .header(SECRET_HEADER, SampleData.secret())
                 ).andReturn();
 
         return result.getResponse().getStatus();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/UpdateTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/UpdateTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import uk.gov.hmcts.reform.draftstore.controllers.DraftController;
+import uk.gov.hmcts.reform.draftstore.controllers.helpers.SampleData;
 import uk.gov.hmcts.reform.draftstore.domain.UpdateDraft;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
@@ -20,15 +21,11 @@ import uk.gov.hmcts.reform.draftstore.service.AuthService;
 import uk.gov.hmcts.reform.draftstore.service.DraftService;
 import uk.gov.hmcts.reform.draftstore.service.UserAndService;
 
-import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.internal.matchers.Null.NULL;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.WARNING;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SECRET_HEADER;
 import static uk.gov.hmcts.reform.draftstore.service.AuthService.SERVICE_HEADER;
@@ -72,19 +69,12 @@ public class UpdateTest {
     }
 
     @Test
-    public void should_set_warning_header_when_encryption_header_is_not_provided() throws Exception {
-        sendUpdate(null)
-            .andExpect(header().string(WARNING, notNullValue()));
-    }
-
-    @Test
-    public void should_NOT_set_warning_header_when_encryption_header_is_provided() throws Exception {
-        sendUpdate(Strings.repeat("?", MIN_SECRET_LENGTH))
-            .andExpect(header().string(WARNING, NULL));
+    public void should_return_400_when_encryption_header_is_not_provided() throws Exception {
+        sendUpdate(null).andExpect(status().isBadRequest());
     }
 
     private ResultActions sendUpdate() throws Exception {
-        return sendUpdate(null);
+        return sendUpdate(SampleData.secret());
     }
 
     private ResultActions sendUpdate(String secret) throws Exception {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/helpers/SampleData.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/controllers/helpers/SampleData.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.draftstore.controllers.helpers;
 
+import com.google.common.base.Strings;
 import uk.gov.hmcts.reform.draftstore.data.model.CreateDraft;
 import uk.gov.hmcts.reform.draftstore.data.model.Draft;
 import uk.gov.hmcts.reform.draftstore.data.model.UpdateDraft;
+import uk.gov.hmcts.reform.draftstore.service.secrets.Secrets;
 
 import java.time.ZonedDateTime;
 
@@ -31,5 +33,9 @@ public class SampleData {
             "some_type",
             maxStaleDays
         );
+    }
+
+    public static String secret() {
+        return Strings.repeat("x", Secrets.MIN_SECRET_LENGTH);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
@@ -45,7 +45,6 @@ import static uk.gov.hmcts.reform.draftstore.service.secrets.Secrets.MIN_SECRET_
     path = "drafts",
     produces = { DraftController.MEDIA_TYPE, MediaType.APPLICATION_JSON_VALUE }
 )
-@SuppressWarnings("checkstyle:LineLength")
 public class DraftController {
 
     static final String MEDIA_TYPE = "application/vnd.uk.gov.hmcts.draft-store.v3+json";

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapper.java
@@ -13,8 +13,8 @@ public class ToDbModelMapper {
         Secrets secrets
     ) {
         return new CreateDraft(
-            secrets.primary != null ? null : draft.document.toString(),
-            secrets.primary != null ? encrypt(draft.document.toString(), secrets.primary) : null,
+            null,
+            encrypt(draft.document.toString(), secrets.primary),
             draft.type,
             draft.maxStaleDays
         );
@@ -25,8 +25,8 @@ public class ToDbModelMapper {
         Secrets secrets
     ) {
         return new UpdateDraft(
-            secrets.primary != null ? null : draft.document.toString(),
-            secrets.primary != null ? encrypt(draft.document.toString(), secrets.primary) : null,
+            null,
+            encrypt(draft.document.toString(), secrets.primary),
             draft.type
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/secrets/SecretsBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/secrets/SecretsBuilder.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.draftstore.service.secrets;
 
 import com.google.common.base.Strings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.draftstore.utils.Lists;
 
 import java.util.Arrays;
@@ -13,16 +11,12 @@ import static uk.gov.hmcts.reform.draftstore.service.secrets.Secrets.MIN_SECRET_
 
 public class SecretsBuilder {
 
-    private static final Logger logger = LoggerFactory.getLogger(SecretsBuilder.class);
-
     public static final String SEPARATOR = ",";
 
     public static Secrets fromHeader(String header) {
 
-        // only during transition stage.
         if (Strings.isNullOrEmpty(header)) {
-            logger.info("No encryption secrets received.");
-            return new Secrets(null, null);
+            throw new SecretsException("Secret is required");
         } else {
             List<String> secrets =
                 Arrays

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/draftservice/UpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/draftservice/UpdateTest.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.draftstore.domain.UpdateDraft;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 import uk.gov.hmcts.reform.draftstore.service.UserAndService;
+import uk.gov.hmcts.reform.draftstore.service.mappers.SampleSecret;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -82,7 +83,7 @@ public class UpdateTest extends BaseTest {
         draftService.update(
             "123",
             new UpdateDraft(new ObjectMapper().createObjectNode(), "some_type"),
-            userAndService
+            userAndService.withSecrets(SampleSecret.getObject())
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/SampleSecret.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/SampleSecret.java
@@ -7,4 +7,8 @@ public class SampleSecret {
     public static String get() {
         return Strings.repeat("x", Secrets.MIN_SECRET_LENGTH);
     }
+
+    public static Secrets getObject() {
+        return new Secrets(get(), null);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/mappers/ToDbModelMapperTest.java
@@ -13,19 +13,11 @@ public class ToDbModelMapperTest {
     private uk.gov.hmcts.reform.draftstore.data.model.CreateDraft result;
 
     @Test
-    public void should_set_only_encrypted_document_when_secret_is_passed() throws Exception {
+    public void should_set_only_encrypted_document() throws Exception {
         result = ToDbModelMapper.toDb(createDraft(), new Secrets(SampleSecret.get(), null));
 
         assertThat(result.document).isNull();
         assertThat(result.encryptedDocument).isNotNull();
-    }
-
-    @Test
-    public void should_set_only_unencrypted_document_when_secret_is_NOT_passed() throws Exception {
-        result = ToDbModelMapper.toDb(createDraft(), new Secrets(null, null));
-
-        assertThat(result.document).isNotNull();
-        assertThat(result.encryptedDocument).isNull();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/secrets/SecretsBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/secrets/SecretsBuilderTest.java
@@ -22,10 +22,8 @@ public class SecretsBuilderTest {
 
     @Test
     public void should_handle_null_header() throws Exception {
-        Secrets secrets = SecretsBuilder.fromHeader(null);
-
-        assertThat(secrets.primary).isNull();
-        assertThat(secrets.secondary).isNull();
+        assertThatThrownBy(() -> SecretsBuilder.fromHeader(null))
+            .isInstanceOf(SecretsException.class);
     }
 
     @Test


### PR DESCRIPTION
### Change description ###
Passing encryption header is now mandatory.
Please note, that this pull request **does not** remove the unencrypted document column from the database. This will have to be done separately in the future once all unencrypted drafts are gone/updated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
