### PR TITLE
Extract swagger documentation to separate module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build
 classes/
 .DS_store
+*.iml
 .gradle
 out/
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,37 +1,44 @@
 plugins {
-  id 'application'
-  id 'checkstyle'
   id 'io.spring.dependency-management' version '1.0.3.RELEASE'
   id 'org.springframework.boot' version '1.5.7.RELEASE'
   id 'org.owasp.dependencycheck' version '1.4.5.1'
   id 'com.github.ben-manes.versions' version '0.15.0'
   id 'org.sonarqube' version '2.5'
-  id 'jacoco'
-  id 'pmd'
 }
 
-group 'uk.gov.hmcts.reform'
+allprojects {
+  apply plugin: 'application'
+  apply plugin: 'jacoco'
+  apply plugin: 'checkstyle'
+  apply plugin: 'pmd'
+
+  group 'uk.gov.hmcts.reform'
+
+  checkstyle.toolVersion = '7.2'
+  checkstyle.configFile = new File(rootDir, "checkstyle.xml")
+
+  // https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
+  dependencyCheck {
+    // Specifies if the build should be failed if a CVSS score above a specified level is identified.
+    // range of 0-10 fails the build, anything greater and it doesn't fail the build
+    failBuildOnCVSS = System.getProperty('dependencyCheck.failBuild') == 'true' ? 0 : 11
+    suppressionFile = 'dependency-check-suppressions.xml'
+  }
+
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
+
+  repositories {
+    jcenter()
+  }
+}
+
 version '1.1.0'
-
-checkstyle.toolVersion = '7.2'
-checkstyle.configFile = new File(rootDir, "checkstyle.xml")
-
-// https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
-dependencyCheck {
-  // Specifies if the build should be failed if a CVSS score above a specified level is identified.
-  // range of 0-10 fails the build, anything greater and it doesn't fail the build
-  failBuildOnCVSS = System.getProperty('dependencyCheck.failBuild') == 'true' ? 0 : 11
-  suppressionFile = 'dependency-check-suppressions.xml'
-}
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
   maven {
     url "https://dl.bintray.com/hmcts/hmcts-maven"
   }
-  jcenter()
 }
 
 sourceSets {
@@ -56,8 +63,7 @@ dependencyManagement {
 
 def versions = [
   springBoot      : springBootVersion,
-  jackson         : dependencyManagement.importedProperties['jackson.version'],
-  springfoxSwagger: '2.7.0'
+  jackson         : dependencyManagement.importedProperties['jackson.version']
 ]
 
 dependencies {
@@ -70,11 +76,12 @@ dependencies {
 
   compile group: 'org.flywaydb', name: 'flyway-core', version: '4.1.2'
 
-  compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
-  compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
+  compileOnly group: 'io.swagger', name: 'swagger-annotations', version: '1.5.17'
 
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
+
+  compile group: 'com.google.guava', name: 'guava', version: '20.0'
 
   compile group: 'org.hibernate', name: 'hibernate-validator', version: '5.4.1.Final'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,33 @@ services:
       - 5429:5432
     volumes:
       - draft-store-database-data:/var/lib/postgresql/data
+  draft-store-swagger:
+    build:
+      context: swagger
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: docker.artifactory.reform.hmcts.net/reform/draft-store-swagger
+    environment:
+      - DRAFT_STORE_DB_HOST=draft-store-database
+      - DRAFT_STORE_DB_PORT
+      - DRAFT_STORE_DB_PASSWORD
+      - ROOT_APPENDER
+      - JSON_CONSOLE_PRETTY_PRINT
+      - ROOT_LOGGING_LEVEL
+      - REFORM_SERVICE_NAME
+      - REFORM_TEAM
+      - REFORM_ENVIRONMENT
+      - IDAM_USE_STUB
+      - S2S_USER_STUB
+    ports:
+      - 8800:8800
+    volumes:
+      - ./swagger/build/install/swagger:/opt/app/
+    depends_on:
+      draft-store-database:
+        condition: service_healthy
 
 volumes:
   draft-store-database-data:

--- a/publish-swagger-docs.sh
+++ b/publish-swagger-docs.sh
@@ -9,7 +9,7 @@ then
 fi
 
 ./gradlew clean installDist
-docker-compose up -d
+docker-compose up -d draft-store-swagger
 sleep 15
 REPO_NAME=$(echo ${TRAVIS_REPO_SLUG} | cut -f2- -d/)
 CURRENT_DOCS=$(curl https://hmcts.github.io/reform-api-docs/specs/${REPO_NAME}.json)

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,5 @@ pluginManagement {
 }
 
 rootProject.name = 'draft-store'
+
+include 'swagger'

--- a/swagger/Dockerfile
+++ b/swagger/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8-jre
+
+COPY build/install/swagger /opt/app/
+
+WORKDIR /opt/app
+
+HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy="" curl --silent --fail http://localhost:8800/health
+
+EXPOSE 8800
+
+ENTRYPOINT ["/opt/app/bin/swagger"]

--- a/swagger/build.gradle
+++ b/swagger/build.gradle
@@ -1,0 +1,21 @@
+group 'uk.gov.hmcts.reform'
+
+def versions = [
+  springfoxSwagger: '2.7.0'
+]
+
+dependencies {
+  compile project(':')
+
+  compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
+  compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
+
+  compile group: 'org.springframework', name: 'spring-context', version: '4.3.13.RELEASE'
+}
+
+run {
+  mainClassName = 'uk.gov.hmcts.reform.draftstore.DraftStoreApplication'
+  if (debug == 'true') {
+    jvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']
+  }
+}

--- a/swagger/src/main/java/uk/gov/hmcts/reform/draftstore/config/SwaggerConfiguration.java
+++ b/swagger/src/main/java/uk/gov/hmcts/reform/draftstore/config/SwaggerConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.draftstore.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
@@ -11,16 +12,17 @@ import uk.gov.hmcts.reform.draftstore.DraftStoreApplication;
 
 @Configuration
 @EnableSwagger2
+@Import(DraftStoreConfig.class)
 public class SwaggerConfiguration {
 
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
-                .useDefaultResponseMessages(false)
-                .select()
-                .apis(RequestHandlerSelectors.basePackage(DraftStoreApplication.BASE_PACKAGE_NAME + ".controllers"))
-                .paths(PathSelectors.any())
-                .build();
+            .useDefaultResponseMessages(false)
+            .select()
+            .apis(RequestHandlerSelectors.basePackage(DraftStoreApplication.BASE_PACKAGE_NAME + ".controllers"))
+            .paths(PathSelectors.any())
+            .build();
     }
 
 }


### PR DESCRIPTION
### Change description ###

Extract swagger documentation to separate module. Affected changes:
- get rid of swagger incurred extra libraries from main application
- docker runs same as usual just building mirror of application including swagger configuration

Cons:
- Would be good to use separate port. Could not make it work
- Would be better to extract port to (environment) properties. Could not make it work for swagger module - still kept on using main application value instead of overridden one

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
