### PR TITLE
Use the same microservice name in terraform and Jenkinsfile

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,7 +8,7 @@ module "db" {
 
 module "api" {
   source        = "git@github.com:hmcts/moj-module-webapp"
-  product       = "${var.product}-api"
+  product       = "${var.product}-${var.microservice}"
   location      = "${var.location_api}"
   env           = "${var.env}"
   ilbIp         = "${var.ilbIp}"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -3,6 +3,11 @@ variable "product" {
   default = "draft-store"
 }
 
+variable "microservice" {
+  type = "string"
+  default = "service"
+}
+
 variable "location_api" {
   type    = "string"
   default = "UK South"


### PR DESCRIPTION
### Change description ###

Use the same microservice name in terraform and Jenkinsfile. The pipeline makes assumptions that those are the same and will fail if they aren't. Currently, in Jenkinsfile the microservice is set to `service`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
