### PR TITLE
Use withParameterizedPipeline method in Jenkinsfile_parameterized

### DIFF
--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -14,6 +14,6 @@ properties([
   pipelineTriggers([[$class: 'GitHubPushTrigger']])
 ])
 
-withPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
+withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
   enableDbMigration()
 }


### PR DESCRIPTION
### Change description ###

Use `withParameterizedPipeline` method in `Jenkinsfile_parameterized`. Current version (`withPipeline`) doesn't work with this set of arguments.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
