### PR TITLE
Add a smoke test for application's health

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ dependencies {
 
   smokeTestCompile sourceSets.main.runtimeClasspath
   smokeTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+  smokeTestCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
 }
 
 task integration(type: Test) {

--- a/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/ApplicationSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/ApplicationSmokeTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.draftstore;
+
+import io.restassured.RestAssured;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@RunWith(SpringRunner.class)
+public class ApplicationSmokeTest {
+
+    @Value("${test-url}")
+    private String testUrl;
+
+    @Test
+    public void service_is_healthy() {
+        RestAssured.baseURI = testUrl;
+
+        RestAssured.given()
+            .relaxedHTTPSValidation()
+            .get("/health")
+            .then()
+            .assertThat()
+            .statusCode(HttpStatus.OK.value())
+            .and()
+            .body("status", equalTo(Status.UP.toString()));
+    }
+}

--- a/src/smokeTest/resources/application.properties
+++ b/src/smokeTest/resources/application.properties
@@ -1,0 +1,1 @@
+test-url=${TEST_URL:http://localhost:8800}


### PR DESCRIPTION
### Change description ###

Add a basic smoke test (checking application's health), so that the build doesn't fail because of the lack of test report. Proper smoke tests are yet to come. This one is there to unblock the pipeline and be able to find other potential issues in further steps.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
