### PR TITLE
Add basic functional test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,8 @@ sonarqube {
 pmd {
   toolVersion = "5.8.1"
   ignoreFailures = true
-  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.integrationTest, sourceSets.smokeTest]
+  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.integrationTest, sourceSets.smokeTest,
+                sourceSets.functionalTest]
   reportsDir = file("$project.buildDir/reports/pmd")
   ruleSetFiles = files("ruleset.xml")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -126,10 +126,7 @@ dependencies {
   functionalTestCompile sourceSets.main.runtimeClasspath
   functionalTestCompile(
     'org.springframework.boot:spring-boot-starter-test',
-    'com.jayway.restassured:rest-assured:2.9.0',
-    'com.warrenstrange:googleauth:1.1.2',
-    'org.assertj:assertj-core:1.7.0',
-    'com.googlecode.lambdaj:lambdaj:2.3.3'
+    'com.jayway.restassured:rest-assured:2.9.0'
   )
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,15 @@ sourceSets {
     }
     resources.srcDir file('src/smokeTest/resources')
   }
+
+  functionalTest {
+    java {
+      compileClasspath += main.output
+      runtimeClasspath += main.output
+      srcDir file('src/functionalTest/java')
+    }
+    resources.srcDir file('src/functionalTest/resources')
+  }
 }
 
 def springBootVersion = '1.5.8.RELEASE'
@@ -113,6 +122,15 @@ dependencies {
   smokeTestCompile sourceSets.main.runtimeClasspath
   smokeTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   smokeTestCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
+
+  functionalTestCompile sourceSets.main.runtimeClasspath
+  functionalTestCompile(
+    'org.springframework.boot:spring-boot-starter-test',
+    'com.jayway.restassured:rest-assured:2.9.0',
+    'com.warrenstrange:googleauth:1.1.2',
+    'org.assertj:assertj-core:1.7.0',
+    'com.googlecode.lambdaj:lambdaj:2.3.3'
+  )
 }
 
 task integration(type: Test) {
@@ -125,6 +143,12 @@ task smoke(type: Test) {
   description = "Runs Smoke Tests"
   testClassesDirs = sourceSets.smokeTest.output.classesDirs
   classpath = sourceSets.smokeTest.runtimeClasspath
+}
+
+task functional(type: Test) {
+  description = "Runs Functional Tests"
+  testClassesDirs = sourceSets.functionalTest.output.classesDirs
+  classpath = sourceSets.functionalTest.runtimeClasspath
 }
 
 task migratePostgresDatabase(type: org.flywaydb.gradle.task.FlywayMigrateTask) {

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ dependencies {
   functionalTestCompile sourceSets.main.runtimeClasspath
   functionalTestCompile(
     'org.springframework.boot:spring-boot-starter-test',
-    'com.jayway.restassured:rest-assured:2.9.0'
+    'io.rest-assured:rest-assured:3.0.7'
   )
 }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/features/security/AuthenticatedRequestTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/features/security/AuthenticatedRequestTest.java
@@ -1,12 +1,11 @@
 package uk.gov.hmcts.reform.draftstore.features.security;
 
+import com.jayway.restassured.RestAssured;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static com.jayway.restassured.RestAssured.given;
 
 @TestPropertySource("classpath:application.properties")
 @RunWith(SpringRunner.class)
@@ -17,15 +16,16 @@ public class AuthenticatedRequestTest {
 
     @Test
     public void rejecting_request_when_missing_required_headers() {
-        given()
+        RestAssured
+            .given()
             .log().all()
             .relaxedHTTPSValidation()
             .baseUri(draftStoreUrl)
             .basePath("/drafts")
             .queryParameter("type", "default")
-        .when()
+            .when()
             .get()
-        .then()
+            .then()
             .assertThat()
             .statusCode(400);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/features/security/AuthenticatedRequestTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/features/security/AuthenticatedRequestTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.draftstore.features.security;
 
-import com.jayway.restassured.RestAssured;
+import io.restassured.RestAssured;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +22,7 @@ public class AuthenticatedRequestTest {
             .relaxedHTTPSValidation()
             .baseUri(draftStoreUrl)
             .basePath("/drafts")
-            .queryParameter("type", "default")
+            .queryParam("type", "default")
             .when()
             .get()
             .then()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/features/security/AuthenticatedRequestTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/features/security/AuthenticatedRequestTest.java
@@ -15,7 +15,7 @@ public class AuthenticatedRequestTest {
     private String draftStoreUrl;
 
     @Test
-    public void rejecting_request_when_missing_required_headers() {
+    public void should_reject_request_when_missing_required_headers() {
         RestAssured
             .given()
             .log().all()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/features/security/AuthenticatedRequestTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/draftstore/features/security/AuthenticatedRequestTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.draftstore.features.security;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static com.jayway.restassured.RestAssured.given;
+
+@TestPropertySource("classpath:application.properties")
+@RunWith(SpringRunner.class)
+public class AuthenticatedRequestTest {
+
+    @Value("${test-url}")
+    private String draftStoreUrl;
+
+    @Test
+    public void rejecting_request_when_missing_required_headers() {
+        given()
+            .log().all()
+            .relaxedHTTPSValidation()
+            .baseUri(draftStoreUrl)
+            .basePath("/drafts")
+            .queryParameter("type", "default")
+        .when()
+            .get()
+        .then()
+            .assertThat()
+            .statusCode(400);
+    }
+}

--- a/src/functionalTest/resources/application.properties
+++ b/src/functionalTest/resources/application.properties
@@ -1,1 +1,1 @@
-test-url=http://localhost:8800
+test-url=${TEST_URL:http://localhost:8800}

--- a/src/functionalTest/resources/application.properties
+++ b/src/functionalTest/resources/application.properties
@@ -1,0 +1,1 @@
+test-url=http://localhost:8800


### PR DESCRIPTION
Functional tests treat tested application as a black box: feeding data
and evaluating results.

Here is the first, basic test that expects HTTP status code 400 when
missing required headers.

https://tools.hmcts.net/jira/browse/RPE-342

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
