### PR TITLE
Fix docker image creation in tactical Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ node {
 
     stage('Package (JAR)') {
       versioner.addJavaVersionInfo()
-      sh "./gradlew bootRepackage installDist"
+      sh "./gradlew installDist"
     }
 
     stage('Package (RPM)') {


### PR DESCRIPTION
### Change description ###

Fix docker image creation in tactical Jenkins. The bootRepackage task breaks the step and doesn't seem to be needed anymore.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
