### PR TITLE
Upgrade dependencycheck plugin to the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.3.RELEASE'
   id 'org.flywaydb.flyway' version '5.0.7'
   id 'org.springframework.boot' version '1.5.7.RELEASE'
-  id 'org.owasp.dependencycheck' version '1.4.5.1'
+  id 'org.owasp.dependencycheck' version '3.1.2'
   id 'com.github.ben-manes.versions' version '0.15.0'
   id 'org.sonarqube' version '2.5'
   id 'jacoco'


### PR DESCRIPTION
### Change description ###

Upgrade dependencycheck plugin to the latest version. This is required, as currently used version doesn't have dependencyCheckAnalyze task, which is executed by Jenkins.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
