### PR TITLE
Fix dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'checkstyle'
   id 'io.spring.dependency-management' version '1.0.5.RELEASE'
   id 'org.flywaydb.flyway' version '5.0.7'
-  id 'org.springframework.boot' version '1.5.12.RELEASE'
+  id 'org.springframework.boot' version '1.5.10.RELEASE'
   id 'org.owasp.dependencycheck' version '3.1.2'
   id 'com.github.ben-manes.versions' version '0.17.0'
   id 'org.sonarqube' version '2.6.2'
@@ -97,6 +97,13 @@ dependencyManagement {
     // bump to 2.8.11.1 because of https://nvd.nist.gov/vuln/detail/CVE-2018-7489
     dependencySet(group: 'com.fasterxml.jackson.core', version: '2.8.11.1') {
       entry 'jackson-databind'
+    }
+    // the url pattern of "" is not correctly handled in tomcat
+    // it is possible for unauthorised users to gain access to web application resources that should have been protected
+    // not bumping tomcat-annotations-api as it introduces way more vulnerabilities than 8.5.27
+    dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.29') {
+      entry 'tomcat-embed-core'
+      entry 'tomcat-embed-websocket'
     }
   }
   imports {

--- a/build.gradle
+++ b/build.gradle
@@ -94,9 +94,14 @@ dependencyManagement {
   dependencies {
     // spring boot dependency management plugin downgrades
     // hystrix related libraries use 2.4.3 and not clear if plan to upgrade
-    // bump to 2.8.11.1 because of https://nvd.nist.gov/vuln/detail/CVE-2018-7489
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.8.11.1') {
+    // bump to 2.9.5 because of https://nvd.nist.gov/vuln/detail/CVE-2018-7489
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.5') {
+      entry 'jackson-annotations'
+      entry 'jackson-core'
       entry 'jackson-databind'
+    }
+    dependencySet(group: 'com.fasterxml.jackson.datatype', version: '2.9.5') {
+      entry 'jackson-datatype-jsr310'
     }
     // the url pattern of "" is not correctly handled in tomcat
     // it is possible for unauthorised users to gain access to web application resources that should have been protected

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,52 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+
+  <!-- server related, mostly applicable to linux. hopefully get better cover with spring boot 2 -->
+
   <suppress>
-    <notes><![CDATA[
-      This has nothing to do with this artifact, it detects nexus in the pom file
-      and thinks that it has something to do with a nexus vulnerability
-      ]]></notes>
-    <gav regex="true">^io\.jsonwebtoken:jjwt:.*$</gav>
-    <cpe>cpe:/a:sonatype:nexus</cpe>
-  </suppress>
-  <suppress>
-    <notes>Does not apply as tomcat is not installed as a service</notes>
-    <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed.*:.*$</gav>
-    <cve>CVE-2016-6325</cve>
-  </suppress>
-  <suppress>
-    <notes>Does not apply as tomcat is not installed as a service</notes>
-    <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed.*:.*$</gav>
+    <notes>
+      <![CDATA[
+## CVE-2016-5425
+
+The Tomcat package on Red Hat Enterprise Linux (RHEL) 7, Fedora, CentOS, Oracle Linux, and possibly other Linux distributions uses weak permissions for /usr/lib/tmpfiles.d/tomcat.conf, which allows local users to gain root privileges by leveraging membership in the tomcat group.
+
+## CVE-2016-6325
+
+The Tomcat package on Red Hat Enterprise Linux (RHEL) 5 through 7, JBoss Web Server 3.0, and JBoss EWS 2 uses weak permissions for (1) /etc/sysconfig/tomcat and (2) /etc/tomcat/tomcat.conf, which allows local users to gain privileges by leveraging membership in the tomcat group.
+
+## CVE-2017-6056
+
+Programming error in the processing of HTTPS requests in the Apache Tomcat servlet and JSP engine may result in denial of service via an infinite loop. The denial of service is easily achievable as a consequence of backporting a CVE-2016-6816 fix but not backporting the fix for Tomcat bug 57544. Distributions affected by this backporting issue include Debian (before 7.0.56-3+deb8u8 and 8.0.14-1+deb8u7 in jessie) and Ubuntu.
+
+## CVE-2018-1304
+
+The URL pattern of "" (the empty string) which exactly maps to the context root was not correctly handled in Apache Tomcat 9.0.0.M1 to 9.0.4, 8.5.0 to 8.5.27, 8.0.0.RC1 to 8.0.49 and 7.0.0 to 7.0.84 when used as part of a security constraint definition. This caused the constraint to be ignored. It was, therefore, possible for unauthorised users to gain access to web application resources that should have been protected. Only security constraints with a URL pattern of the empty string were affected.
+]]>
+    </notes>
+    <gav regex="true">org\.apache\.tomcat:tomcat-annotations-api:8\.5\.27</gav>
     <cve>CVE-2016-5425</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      only effects distribution based tomcat that has been backported.
-      our tomcat version has the fix in it
-      ]]></notes>
-    <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-websocket:.*$</gav>
+    <cve>CVE-2016-6325</cve>
     <cve>CVE-2017-6056</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      only effects distribution based tomcat that has been backported.
-      our tomcat version has the fix in it
-      ]]></notes>
-    <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-core:.*$</gav>
-    <cve>CVE-2017-6056</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      Does not apply as we're not using the XmlMapper.
-    ]]></notes>
-    <gav regex="true">^com\.fasterxml\.jackson\.(core|datatype|module):jackson-.*:.*$</gav>
-    <cve>CVE-2016-7051</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-  Suppressing for demo (the service is not live)
-]]></notes>
-    <gav regex="true">^.*$</gav>
-    <cvssBelow>10</cvssBelow>
+    <cve>CVE-2018-1304</cve>
+    <cve>CVE-2018-1305</cve>
   </suppress>
 
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -39,4 +39,22 @@ The URL pattern of "" (the empty string) which exactly maps to the context root 
     <cve>CVE-2017-14798</cve>
   </suppress>
 
+  <!-- not used by server -->
+
+  <suppress>
+    <notes><![CDATA[Used only for testing not used in prod]]></notes>
+    <gav regex="true">^org\.testcontainers:postgresql:.*$</gav>
+    <cpe>cpe:/a:postgresql:postgresql</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[Related to Groovy LDAP API which is not used by the service]]></notes>
+    <gav regex="true">^org\.codehaus\.groovy:groovy-xml:.*$</gav>
+    <cpe>cpe:/a:apache:groovy</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[Related to Groovy LDAP API which is not used by the service]]></notes>
+    <gav regex="true">^org\.codehaus\.groovy:groovy-json:.*$</gav>
+    <cve>CVE-2016-6497</cve>
+  </suppress>
+
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -21,6 +21,10 @@ Programming error in the processing of HTTPS requests in the Apache Tomcat servl
 ## CVE-2018-1304
 
 The URL pattern of "" (the empty string) which exactly maps to the context root was not correctly handled in Apache Tomcat 9.0.0.M1 to 9.0.4, 8.5.0 to 8.5.27, 8.0.0.RC1 to 8.0.49 and 7.0.0 to 7.0.84 when used as part of a security constraint definition. This caused the constraint to be ignored. It was, therefore, possible for unauthorised users to gain access to web application resources that should have been protected. Only security constraints with a URL pattern of the empty string were affected.
+
+## CVE-2018-1305
+
+Security constraints defined by annotations of Servlets in Apache Tomcat 9.0.0.M1 to 9.0.4, 8.5.0 to 8.5.27, 8.0.0.RC1 to 8.0.49 and 7.0.0 to 7.0.84 were only applied once a Servlet had been loaded. Because security constraints defined in this way apply to the URL pattern and any URLs below that point, it was possible - depending on the order Servlets were loaded - for some security constraints not to be applied. This could have exposed resources to users who were not authorised to access them.
 ]]>
     </notes>
     <gav regex="true">org\.apache\.tomcat:tomcat-annotations-api:8\.5\.27</gav>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -31,4 +31,12 @@ The URL pattern of "" (the empty string) which exactly maps to the context root 
     <cve>CVE-2018-1305</cve>
   </suppress>
 
+  <!-- postgresql -->
+
+  <suppress>
+    <notes><![CDATA[A race condition in the postgresql init script could be used by attackers able to access the postgresql account to escalate their privileges to root]]></notes>
+    <gav regex="true">org\.postgresql:postgresql:42\.1\.4</gav>
+    <cve>CVE-2017-14798</cve>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Remediate suppressed dependencies across micro services](https://tools.hmcts.net/jira/browse/RPE-405)

### Change description ###

- spring boot downgraded to `1.5.10` because `1.5.12` pulled in `tomcat-annotations-api-8.5.29` which has a lot of vulnerabilities compared to enlisted `8.5.27` version (see suppression file)
- missed dependency update of `jackson` lib in previous (#139) pr. #136 upgraded the `java-logging` library which has latest stable `jackson` library implemented

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
