### PR TITLE
Return Idam auth token after user registration

### DIFF
--- a/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/SmokeTestSuite.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/SmokeTestSuite.java
@@ -82,7 +82,8 @@ public abstract class SmokeTestSuite {
             .map(code -> idamClient.getIdamToken(code))
             .orElseGet(() -> {
                 idamClient.registerUser();
-                return idamClient.getAuthorisationCode(true).get();
+                String code = idamClient.getAuthorisationCode(true).get();
+                return idamClient.getIdamToken(code);
             });
     }
 


### PR DESCRIPTION
### Change description ###

Bug fix: return Idam auth token after user registration. Previously, it was authorisation code (bug was introduced during code refactoring).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
