### PR TITLE
Delete smoke test user before creation attempt

### DIFF
--- a/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/SmokeTestSuite.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/SmokeTestSuite.java
@@ -81,6 +81,7 @@ public abstract class SmokeTestSuite {
         return authorisationCode
             .map(code -> idamClient.getIdamToken(code))
             .orElseGet(() -> {
+                idamClient.deleteUser();
                 idamClient.registerUser();
                 String code = idamClient.getAuthorisationCode(true).get();
                 return idamClient.getIdamToken(code);

--- a/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/client/IdamClient.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/client/IdamClient.java
@@ -8,7 +8,9 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.isOneOf;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
@@ -54,6 +56,19 @@ public class IdamClient {
             .post(idamUrl + "/testing-support/accounts")
             .then()
             .statusCode(NO_CONTENT.value());
+    }
+
+    /**
+     * Deletes the user with Idam's testing support.
+     */
+    public void deleteUser() {
+        RestAssured
+            .given()
+            .relaxedHTTPSValidation()
+            .baseUri(this.idamUrl)
+            .delete("/testing-support/accounts/{email}", email)
+            .then()
+            .statusCode(isOneOf(NO_CONTENT.value(), NOT_FOUND.value()));
     }
 
     public Optional<String> getAuthorisationCode(boolean failIfUnauthorised) {


### PR DESCRIPTION
### Change description ###

If there's an Idam authentication failure on user login, smoke tests make an attempt to create that user and try to log them in again. However, if the user already exists but is locked, creation won't change their state and the tests will end up in a forever failing state. That's why before creating the user we should make sure the user doesn't exist.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
