### PR TITLE
Let smoke tests use Idam testing support only where it's available

### DIFF
--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -38,4 +38,8 @@ output "idam_redirect_uri_for_tests" {
   value = "https://cmc-citizen-frontend-aat-staging.service.core-compute-aat.internal/receiver"
 }
 
+output "use_idam_testing_support" {
+  value = "${var.use_idam_testing_support}"
+}
+
 # endregion

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,2 +1,3 @@
 idam_api_url = "https://prod-idamapi.reform.hmcts.net:3511"
 vault_section = "prod"
+use_idam_testing_support = "false"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -58,4 +58,8 @@ variable "run_db_migration_on_startup" {
   default = "false"
 }
 
+variable "use_idam_testing_support" {
+  default = "true"
+}
+
 # endregion

--- a/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/SmokeTestSuite.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/SmokeTestSuite.java
@@ -48,6 +48,9 @@ public abstract class SmokeTestSuite {
     @Value("${draft-store-url}")
     protected String draftStoreUrl;
 
+    @Value("${use-idam-testing-support")
+    protected boolean useIdamTestingSupport;
+
     protected DraftStoreClient draftStoreClient;
 
     @Before
@@ -76,7 +79,9 @@ public abstract class SmokeTestSuite {
      * @return Idam access token
      */
     private String signIntoIdam(IdamClient idamClient) {
-        Optional<String> authorisationCode = idamClient.getAuthorisationCode(false);
+        boolean failIfUnauthorised = !useIdamTestingSupport;
+
+        Optional<String> authorisationCode = idamClient.getAuthorisationCode(failIfUnauthorised);
 
         return authorisationCode
             .map(code -> idamClient.getIdamToken(code))

--- a/src/smokeTest/resources/application.properties
+++ b/src/smokeTest/resources/application.properties
@@ -8,3 +8,4 @@ idam-password=${IDAM_PASSWORD_FOR_TESTS}
 idam-client-id=${IDAM_CLIENT_ID_FOR_TESTS}
 idam-client-secret=${IDAM_CLIENT_SECRET_FOR_TESTS}
 idam-redirect-uri=${IDAM_REDIRECT_URI_FOR_TESTS}
+use-idam-testing-support=${USE_IDAM_TESTING_SUPPORT}


### PR DESCRIPTION
### Change description ###

Let smoke tests use Idam testing support only in environments where it's available (i.e. not in production)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
