### PR TITLE
Make redirect-uris for Idam (tests only) environment-specific

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,2 +1,3 @@
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
 vault_section = "preprod"
+idam_redirect_uri_for_tests = "https://cmc-citizen-frontend-aat-staging.service.core-compute-aat.internal/receiver"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,2 +1,3 @@
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
 vault_section = "preprod"
+idam_redirect_uri_for_tests = "https://cmc-citizen-frontend-aat-staging.service.core-compute-aat.internal/receiver"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -35,7 +35,7 @@ output "idam_client_id_for_tests" {
 
 // One of the whitelisted URLs - tests need to use it in order to log user in
 output "idam_redirect_uri_for_tests" {
-  value = "https://cmc-citizen-frontend-aat-staging.service.core-compute-aat.internal/receiver"
+  value = "${var.idam_redirect_uri_for_tests}"
 }
 
 output "use_idam_testing_support" {

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,3 +1,4 @@
 idam_api_url = "https://prod-idamapi.reform.hmcts.net:3511"
 vault_section = "prod"
 use_idam_testing_support = "false"
+idam_redirect_uri_for_tests = "https://cmc-citizen-frontend-prod.service.core-compute-prod.internal/receiver"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -63,3 +63,13 @@ variable "use_idam_testing_support" {
 }
 
 # endregion
+
+# region test config
+
+# redirect-uri to be used by end-to-end tests when signing user in to Idam (must be whitelisted)
+variable "idam_redirect_uri_for_tests" {
+  # despite what it looks like, this is an actual whitelisted URI for test env
+  default = "https://i-am-not-used/receiver"
+}
+
+# endregion


### PR DESCRIPTION
### Change description ###

Make redirect-uris for Idam (tests only) environment-specific.

In order to log a test user into Idam, smoke/functional tests need to provide `redirect-uri` paramter. In our case that URI doesn't matter, as long as it's whitelisted. Each environment has its own whitelist, which has to be reflected in our configuration.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
