### PR TITLE
Delete stale drafts with null max stale days field

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/controllers/helpers/SampleData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/controllers/helpers/SampleData.java
@@ -26,7 +26,7 @@ public final class SampleData {
         return new UpdateDraft("{}", null, "some_type");
     }
 
-    public static CreateDraft createDraft(int maxStaleDays) {
+    public static CreateDraft createDraft(Integer maxStaleDays) {
         return new CreateDraft(
             "{}",
             null,

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDao.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDao.java
@@ -38,6 +38,7 @@ public class DraftStoreDao {
 
     /**
      * Creates a new draft.
+     *
      * @return id of newly created draft.
      */
     public int insert(String userId, String service, CreateDraft newDraft) {
@@ -126,8 +127,10 @@ public class DraftStoreDao {
     public void deleteStaleDrafts() {
         jdbcTemplate.update(
             "DELETE FROM draft_document "
-                + "WHERE updated + interval '1 day' * max_stale_days < :now",
-            new MapSqlParameterSource("now", Timestamp.from(this.clock.instant()))
+                + "WHERE updated + interval '1 day' * COALESCE(max_stale_days, :defaultMaxStaleDays) < :now",
+            new MapSqlParameterSource()
+                .addValue("now", Timestamp.from(this.clock.instant()))
+                .addValue("defaultMaxStaleDays", this.defaultMaxStaleDays)
         );
     }
 


### PR DESCRIPTION
uses 'default max stale days' from config for such drafts