### PR TITLE
Set IdAM test user's password in terraform

### DIFF
--- a/infrastructure/test_config.tf
+++ b/infrastructure/test_config.tf
@@ -20,3 +20,21 @@ resource "azurerm_key_vault_secret" "idam-client-secret-for-tests" {
   value     = "${data.vault_generic_secret.test_idam_client_secret.data["value"]}"
   vault_uri = "${module.key-vault.key_vault_uri}"
 }
+
+#region IdAM test user's password
+
+resource "random_string" "idam_password" {
+  length = 16
+  special = false
+}
+
+# This is set only for environments where IdAM testing support is on.
+# In other environments (e.g. prod) real IdAM password has to be manually set in Azure Vault
+resource "azurerm_key_vault_secret" "idam_password_for_tests" {
+  name      = "idam-password-for-tests"
+  value     = "${random_string.idam_password.result}"
+  vault_uri = "${module.key-vault.key_vault_uri}"
+  count     = "${var.use_idam_testing_support == "true" ? 1 : 0}"
+}
+
+#endregion


### PR DESCRIPTION
### Change description ###

This password is set only in those environments where IdAM's testing support is on. It still has to be set manually everywhere else.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
