### PR TITLE
Disable migrations on sandbox

### DIFF
--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -30,6 +30,7 @@ properties([
 ])
 
 withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
-  enableDbMigration()
+  // migrations disabled temporarily, sandbox jenkins does not have access to tactical envs.
+  // enableDbMigration()
   loadVaultSecrets(secrets)
 }


### PR DESCRIPTION
Currently builds on sandbox fail, as jenkins tries to run migration but does not have access to tactical env db.