### PR TITLE
Update idam redirect url for sandbox smoke tests

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -71,8 +71,7 @@ variable "use_idam_testing_support" {
 
 # redirect-uri to be used by end-to-end tests when signing user in to Idam (must be whitelisted)
 variable "idam_redirect_uri_for_tests" {
-  # despite what it looks like, this is an actual whitelisted URI for test env
-  default = "https://i-am-not-used/receiver"
+  default = "https://cmc-citizen-frontend-saat-staging.service.core-compute-saat.internal/receiver"
 }
 
 # endregion


### PR DESCRIPTION
Previously used `https://i-am-not-used/receiver` is no longer whitelisted
(it was removed in https://github.com/hmcts/idam-ansible/pull/38/files) 