### PR TITLE
Smoke tests: use idam test support fully

### DIFF
--- a/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/client/IdamClient.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/draftstore/client/IdamClient.java
@@ -51,7 +51,7 @@ public class IdamClient {
             .given()
             .relaxedHTTPSValidation()
             .baseUri(this.idamUrl)
-            .get("/testing-support/lease")
+            .post("/testing-support/lease?id=1&role=citizen")
             .getBody()
             .asString();
     }


### PR DESCRIPTION
Instead of creating (and deleting) new users when test support endpoint is available, just retrieve an 'artificial' jwt token from idam.