### PR TITLE
Clearer exception for idam token validation errors

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/GetByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/GetByIdTest.java
@@ -39,6 +39,8 @@ public class GetByIdTest {
     // TODO: create a separate test for checking exception mapping in the app in general.
     @Test
     public void should_map_no_draft_exception_to_404() throws Exception {
+        givenIsAuthenticated();
+
         BDDMockito
             .given(draftService.read(anyString(), any(UserAndService.class)))
             .willThrow(new NoDraftFoundException());
@@ -73,16 +75,20 @@ public class GetByIdTest {
 
     @Test
     public void should_return_200_if_draft_is_found() throws Exception {
+        givenIsAuthenticated();
+
         int status = callGet();
 
         assertThat(status).isEqualTo(HttpStatus.OK.value());
     }
 
-    private int callGet() throws Exception {
+    private void givenIsAuthenticated() {
         BDDMockito
             .given(authService.authenticate(anyString(), anyString()))
             .willReturn(new UserAndService("john", "service"));
+    }
 
+    private int callGet() throws Exception {
         MvcResult result =
             mockMvc
                 .perform(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/GetByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/controllers/draftcontroller/GetByIdTest.java
@@ -16,6 +16,8 @@ import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 import uk.gov.hmcts.reform.draftstore.service.AuthService;
 import uk.gov.hmcts.reform.draftstore.service.DraftService;
 import uk.gov.hmcts.reform.draftstore.service.UserAndService;
+import uk.gov.hmcts.reform.draftstore.service.idam.InvalidIdamTokenException;
+import uk.gov.hmcts.reform.draftstore.service.s2s.InvalidServiceTokenException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +36,7 @@ public class GetByIdTest {
     @MockBean private DraftService draftService;
     @MockBean private AuthService authService;
 
+    // TODO: create a separate test for checking exception mapping in the app in general.
     @Test
     public void should_map_no_draft_exception_to_404() throws Exception {
         BDDMockito
@@ -44,6 +47,28 @@ public class GetByIdTest {
 
         assertThat(status).isEqualTo(HttpStatus.NOT_FOUND.value());
 
+    }
+
+    @Test
+    public void should_map_InvalidIdamTokenException_to_401() throws Exception {
+        BDDMockito
+            .given(authService.authenticate(anyString(), anyString()))
+            .willThrow(new InvalidIdamTokenException("msg", null));
+
+        int status = callGet();
+
+        assertThat(status).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    public void should_map_InvalidServiceTokenException_to_401() throws Exception {
+        BDDMockito
+            .given(authService.authenticate(anyString(), anyString()))
+            .willThrow(new InvalidServiceTokenException("msg", null));
+
+        int status = callGet();
+
+        assertThat(status).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/EndpointExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/EndpointExceptionHandler.java
@@ -164,7 +164,7 @@ public class EndpointExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(InvalidServiceTokenException.class)
-    public ResponseEntity<ErrorResult> handleInvalidSerbiceTokenException(HttpServletRequest req, Exception exc) {
+    public ResponseEntity<ErrorResult> handleInvalidServiceTokenException(HttpServletRequest req, Exception exc) {
         log.warn(exc.getMessage(), exc);
         return new ResponseEntity<>(
             new ErrorResult(INVALID_SERVICE_AUTH_TOKEN, emptyList()),

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/EndpointExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/EndpointExceptionHandler.java
@@ -9,13 +9,13 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.draftstore.domain.ErrorResult;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 import uk.gov.hmcts.reform.draftstore.service.crypto.InvalidKeyException;
+import uk.gov.hmcts.reform.draftstore.service.idam.InvalidIdamTokenException;
 import uk.gov.hmcts.reform.draftstore.service.secrets.SecretsException;
 
 import java.util.List;
@@ -29,6 +29,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.BAD_ARGUMENT;
 import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.INVALID_AUTH_TOKEN;
 import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.NO_RECORD_FOUND;
@@ -151,12 +152,12 @@ public class EndpointExceptionHandler extends ResponseEntityExceptionHandler {
         );
     }
 
-    @ExceptionHandler(HttpClientErrorException.class)
-    public ResponseEntity<ErrorResult> unknownException(HttpServletRequest req, HttpClientErrorException exc) {
+    @ExceptionHandler(InvalidIdamTokenException.class)
+    public ResponseEntity<ErrorResult> handleInvalidIdamTokenException(HttpServletRequest req, Exception exc) {
         log.warn(exc.getMessage(), exc);
         return new ResponseEntity<>(
             new ErrorResult(INVALID_AUTH_TOKEN, emptyList()),
-            exc.getStatusCode()
+            UNAUTHORIZED
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/EndpointExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/EndpointExceptionHandler.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 import uk.gov.hmcts.reform.draftstore.service.crypto.InvalidKeyException;
 import uk.gov.hmcts.reform.draftstore.service.idam.InvalidIdamTokenException;
+import uk.gov.hmcts.reform.draftstore.service.s2s.InvalidServiceTokenException;
 import uk.gov.hmcts.reform.draftstore.service.secrets.SecretsException;
 
 import java.util.List;
@@ -32,6 +33,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.BAD_ARGUMENT;
 import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.INVALID_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.INVALID_SERVICE_AUTH_TOKEN;
 import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.NO_RECORD_FOUND;
 import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.SERVER_ERROR;
 import static uk.gov.hmcts.reform.draftstore.domain.ErrorCode.USER_DETAILS_SERVICE_ERROR;
@@ -157,6 +159,15 @@ public class EndpointExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn(exc.getMessage(), exc);
         return new ResponseEntity<>(
             new ErrorResult(INVALID_AUTH_TOKEN, emptyList()),
+            UNAUTHORIZED
+        );
+    }
+
+    @ExceptionHandler(InvalidServiceTokenException.class)
+    public ResponseEntity<ErrorResult> handleInvalidSerbiceTokenException(HttpServletRequest req, Exception exc) {
+        log.warn(exc.getMessage(), exc);
+        return new ResponseEntity<>(
+            new ErrorResult(INVALID_SERVICE_AUTH_TOKEN, emptyList()),
             UNAUTHORIZED
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/domain/ErrorCode.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/domain/ErrorCode.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.draftstore.domain;
 
 public enum ErrorCode {
     INVALID_AUTH_TOKEN,
+    INVALID_SERVICE_AUTH_TOKEN,
     BAD_ARGUMENT,
     NO_RECORD_FOUND,
     SERVER_ERROR,

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientImpl.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.draftstore.service.idam;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -22,12 +23,17 @@ public class IdamClientImpl implements IdamClient {
         HttpHeaders headers = new HttpHeaders();
         headers.add(AUTHORIZATION, authHeader);
 
-        return restTemplate
-            .exchange(
-                idamUrl + "/details",
-                HttpMethod.GET,
-                new HttpEntity<String>(headers),
-                User.class
-            ).getBody();
+        try {
+            return restTemplate
+                .exchange(
+                    idamUrl + "/details",
+                    HttpMethod.GET,
+                    new HttpEntity<String>(headers),
+                    User.class
+                ).getBody();
+
+        } catch (HttpClientErrorException exc) {
+            throw new InvalidIdamTokenException(exc.getMessage(), exc);
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/IdamClientImpl.java
@@ -32,7 +32,7 @@ public class IdamClientImpl implements IdamClient {
                     User.class
                 ).getBody();
 
-        } catch (HttpClientErrorException exc) {
+        } catch (HttpClientErrorException exc) { // idam returns 401 if token is invalid...
             throw new InvalidIdamTokenException(exc.getMessage(), exc);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/InvalidIdamTokenException.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/idam/InvalidIdamTokenException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.draftstore.service.idam;
+
+public class InvalidIdamTokenException extends RuntimeException {
+
+    public InvalidIdamTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/s2s/InvalidServiceTokenException.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/s2s/InvalidServiceTokenException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.draftstore.service.s2s;
+
+public class InvalidServiceTokenException extends RuntimeException {
+
+    public InvalidServiceTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/s2s/S2sClientImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/s2s/S2sClientImpl.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.draftstore.service.s2s;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -21,12 +22,17 @@ public class S2sClientImpl implements S2sClient {
         HttpHeaders headers = new HttpHeaders();
         headers.add(AUTHORIZATION, authHeader);
 
-        return restTemplate
-            .exchange(
-                url + "/details",
-                HttpMethod.GET,
-                new HttpEntity<String>(headers),
-                String.class
-            ).getBody();
+        try {
+            return restTemplate
+                .exchange(
+                    url + "/details",
+                    HttpMethod.GET,
+                    new HttpEntity<String>(headers),
+                    String.class
+                ).getBody();
+
+        } catch (HttpClientErrorException exc) { // s2s throws 401 if token is invalid...
+            throw new InvalidServiceTokenException(exc.getMessage(), exc);
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/s2s/S2sClientImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/s2s/S2sClientImpl.java
@@ -31,7 +31,7 @@ public class S2sClientImpl implements S2sClient {
                     String.class
                 ).getBody();
 
-        } catch (HttpClientErrorException exc) { // s2s throws 401 if token is invalid...
+        } catch (HttpClientErrorException exc) { // s2s returns 401 if token is invalid...
             throw new InvalidServiceTokenException(exc.getMessage(), exc);
         }
     }


### PR DESCRIPTION
`HttpClientErrorException` was quite vague in logs.
Wrapped in custom runtime exceptions so that it's clear we were validating Idam/s2s token.