### PR TITLE
[SKIP-PREVIEW] Fix db cleanup in tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DataAgent.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DataAgent.java
@@ -33,4 +33,8 @@ public class DataAgent {
             new MapSqlParameterSource("userId", userId)
         );
     }
+
+    public void deleteAll() {
+        jdbcTemplate.update("DELETE FROM draft_document", new MapSqlParameterSource());
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDaoTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDaoTest.java
@@ -35,8 +35,7 @@ public class DraftStoreDaoTest {
 
     @Before
     public void cleanDb() {
-        dataAgent.deleteDocuments(USER_ID);
-        dataAgent.deleteDocuments(ANOTHER_USER_ID);
+        dataAgent.deleteAll();
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDaoTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDaoTest.java
@@ -79,10 +79,10 @@ public class DraftStoreDaoTest {
 
     @Test
     public void readAll_should_return_all_matching_drafts() throws SQLException {
-        dataAgent.setupDocumentForUser("id", "t", "[1]");
-        dataAgent.setupDocumentForUser("id", "t", "[2]");
+        dataAgent.setupDocumentForUser(USER_ID, "t", "[1]");
+        dataAgent.setupDocumentForUser(USER_ID, "t", "[2]");
 
-        List<Draft> drafts = underTest.readAll("id", "cmc", null, 10);
+        List<Draft> drafts = underTest.readAll(USER_ID, "cmc", null, 10);
 
         assertThat(drafts).hasSize(2);
         assertThat(drafts).extracting("document").contains("[1]", "[2]");


### PR DESCRIPTION
depending on the tests order, some would fail, because this:
```
    @Before
    public void cleanDb() {
        dataAgent.deleteDocuments(USER_ID);
        dataAgent.deleteDocuments(ANOTHER_USER_ID);
    }
```
did not remove all the drafts (see changes below)