### PR TITLE
Revert "Changing IDAM URL to point back to tactical from strategic"

### DIFF
--- a/infrastructure/saat.tfvars
+++ b/infrastructure/saat.tfvars
@@ -1,1 +1,0 @@
-idam_api_url = "http://betadevbccidamapplb.reform.hmcts.net/"


### PR DESCRIPTION
This results with draft-store pointing back to the strategic saat IdAM, as requested.