### PR TITLE
Disable idam testing support on saat env

### DIFF
--- a/infrastructure/saat.tfvars
+++ b/infrastructure/saat.tfvars
@@ -1,1 +1,2 @@
+use_idam_testing_support = "false"
 idam_api_url = "http://idam-api-idam-saat.service.core-compute-saat.internal"


### PR DESCRIPTION
strategic IDAM doesn't have this endpoint anyway