### PR TITLE
Drop port in IDAM url

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,4 +1,4 @@
-idam_api_url = "https://prod-idamapi.reform.hmcts.net:3511"
+idam_api_url = "https://prod-idamapi.reform.hmcts.net"
 vault_section = "prod"
 use_idam_testing_support = "false"
 idam_redirect_uri_for_tests = "https://cmc-citizen-frontend-prod.service.core-compute-prod.internal/receiver"


### PR DESCRIPTION
Needed for SIDAM go-live, CMC have been using the version without a port for weeks,
App services don't support a port in the url, on go-live it'll be a DNS switch but the port must not be there