### PR TITLE
Add basic nightly pipeline

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,5 +1,10 @@
 #!groovy
 
+properties([
+    // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
+    pipelineTriggers([cron('H 05 * * *')])
+])
+
 @Library("Infrastructure")
 
 def type = "java"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,0 +1,12 @@
+#!groovy
+
+@Library("Infrastructure")
+
+def type = "java"
+def product = "draft-store"
+def app = "service"
+def channel = '#rpe-build-notices'
+
+withNightlyPipeline(type, product, app) {
+  enableSlackNotifications(channel)
+}


### PR DESCRIPTION
### Change description ###

Add support for nightly OWASP dependency checks with slack notifications.

Successful build here https://build.platform.hmcts.net/job/HMCTS_Nightly/job/draft-store/job/nightly-pipeline/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
