### PR TITLE
Update to new idam prod url

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,4 +1,4 @@
-idam_api_url = "https://prod-idamapi.reform.hmcts.net"
+idam_api_url = "https://idam-api.platform.hmcts.net"
 vault_section = "prod"
 use_idam_testing_support = "false"
 idam_redirect_uri_for_tests = "https://cmc-citizen-frontend-prod.service.core-compute-prod.internal/receiver"


### PR DESCRIPTION
### JIRA link (if applicable) ###
-


### Change description ###
Idam is migrating to the platform domain, so that after the DNS switch for SIDAM it will be on the new domain, a request should have came through for us to update it but draft-store must've been missed
https://github.com/hmcts/cmc-citizen-frontend/pull/875/files


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
