### PR TITLE
[PREVIEW] Remove (Hashicorp) vault provider config from infrastructure code

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,6 +1,3 @@
-provider "vault" {
-  address = "https://vault.reform.hmcts.net:6200"
-}
 
 locals {
   db_connection_options  = "?ssl=true"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Remove (Hashicorp) vault provider config from infrastructure code. We're not using Hashicorp vault anymore.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
