### PR TITLE
[PREVIEW] Stop reading test secrets from Hashicorp Vault

### DIFF
--- a/infrastructure/test_config.tf
+++ b/infrastructure/test_config.tf
@@ -1,28 +1,5 @@
 # configuration for end-to-end tests
 
-// TODO: use the draft store test microservice once https://github.com/hmcts/service-auth-provider-app/pull/27 is merged
-data "vault_generic_secret" "tests_s2s_secret" {
-  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/send-letter-tests"
-}
-
-data "vault_generic_secret" "test_idam_client_secret" {
-  path = "secret/${var.vault_section}/ccidam/idam-api/oauth2/client-secrets/cmc-citizen"
-}
-
-resource "azurerm_key_vault_secret" "s2s-secret-for-tests" {
-  name      = "s2s-secret-for-tests"
-  value     = "${data.vault_generic_secret.tests_s2s_secret.data["value"]}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
-}
-
-resource "azurerm_key_vault_secret" "idam-client-secret-for-tests" {
-  name      = "idam-client-secret-for-tests"
-  value     = "${data.vault_generic_secret.test_idam_client_secret.data["value"]}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
-}
-
-#region IdAM test user's password
-
 resource "random_string" "idam_password" {
   length = 16
   special = false
@@ -36,5 +13,3 @@ resource "azurerm_key_vault_secret" "idam_password_for_tests" {
   vault_uri = "${module.key-vault.key_vault_uri}"
   count     = "${var.use_idam_testing_support == "true" ? 1 : 0}"
 }
-
-#endregion


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Stop reading test secrets from Hashicorp Vault - they're already stored in Azure Key Vaults.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
