### PR TITLE
[PREVIEW] Retrieve test secrets from Azure Key Vault and not Hashicorp Vault

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,11 +26,16 @@ locals {
                                  ? local.preview_vault_name
                                  : local.default_vault_name
                              }"
+
+  # URI of vault that stores long-term secrets. It's the app's own Key Vault, except for (s)preview,
+  # where vaults are short-lived and can only store secrets generated during deployment
+  permanent_vault_uri    = "https://${var.raw_product}-${local.dependencies_env}.vault.azure.net/"
 }
 
+# TODO: remove once the DB is migrated to CNP
 data "azurerm_key_vault_secret" "db_password" {
   name      = "db-password"
-  vault_uri = "https://${var.raw_product}-${local.dependencies_env}.vault.azure.net/"
+  vault_uri = "${local.permanent_vault_uri}"
 }
 
 module "api" {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -3,7 +3,7 @@ output "vaultUri" {
 }
 
 output "vaultName" {
-  value = "${local.vault_name}"
+  value = "${module.key-vault.key_vault_name}"
 }
 
 output "microserviceName" {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Retrieve test secrets from Azure Key Vault and not Hashicorp Vault

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
