### PR TITLE
[PREVIEW] Retrieve test s2s key directly from s2s's vault

### DIFF
--- a/infrastructure/test_config.tf
+++ b/infrastructure/test_config.tf
@@ -1,12 +1,9 @@
 # configuration for end-to-end tests
 
-# Secrets for tests are stored in permanent (long-lived) Azure Key Vault instances.
-# With the exception of (s)preview all Vault instances are long-lived. For preview, however,
-# test secrets (not created during deployment) need to be copied over from a permanent vault -
-# that's what the code below does.
+#region Copying the test microservice key from s2s's vault to app's own vault
 data "azurerm_key_vault_secret" "source_s2s-secret-for-tests" {
-  name      = "s2s-secret-for-tests"
-  vault_uri = "${local.permanent_vault_uri}"
+  name      = "microservicekey-draftStoreTests"
+  vault_uri = "https://s2s-${local.dependencies_env}.vault.azure.net/"
 }
 
 resource "azurerm_key_vault_secret" "s2s-secret-for-tests" {
@@ -14,7 +11,12 @@ resource "azurerm_key_vault_secret" "s2s-secret-for-tests" {
   value     = "${data.azurerm_key_vault_secret.source_s2s-secret-for-tests.value}"
   vault_uri = "${module.key-vault.key_vault_uri}"
 }
+#endregion
 
+# Secrets for tests are stored in permanent (long-lived) Azure Key Vault instances.
+# With the exception of (s)preview all Vault instances are long-lived. For preview, however,
+# test secrets (not created during deployment) need to be copied over from a permanent vault -
+# that's what the code below does.
 data "azurerm_key_vault_secret" "source_idam-client-secret-for-tests" {
   name      = "idam-client-secret-for-tests"
   vault_uri = "${local.permanent_vault_uri}"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Retrieve test s2s key directly from s2s's vault. Before this change it was kept independently in draft-store's vault.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
