### PR TITLE
[PREVIEW] Add a prefix to DB server name

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -75,7 +75,7 @@ module "api" {
 
 module "db" {
   source              = "git@github.com:hmcts/moj-module-postgres?ref=master"
-  product             = "${var.product}-db"
+  product             = "rpe-${var.product}-db"
   location            = "${var.location_api}"
   env                 = "${var.env}"
   database_name       = "draftstore"


### PR DESCRIPTION
### Change description ###

Add a prefix to DB server name so that it's globally unique. Currently, there's a name conflict in demo.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
