### PR TITLE
Simplify secret length validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,8 +125,6 @@ dependencies {
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
-  compile group: 'org.hibernate', name: 'hibernate-validator', version: '5.4.1.Final'
-
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '2.2.1'
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '2.2.1'
 

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/DraftController.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.draftstore.controllers;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.hibernate.validator.constraints.Length;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -30,6 +29,7 @@ import uk.gov.hmcts.reform.draftstore.service.secrets.SecretsBuilder;
 
 import java.net.URI;
 import javax.validation.Valid;
+import javax.validation.constraints.Size;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.ResponseEntity.created;
@@ -102,7 +102,7 @@ public class DraftController {
     public ResponseEntity<Void> create(
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestHeader(SERVICE_HEADER) String serviceHeader,
-        @RequestHeader(SECRET_HEADER) @Valid @Length(min = MIN_SECRET_LENGTH) String secretHeader,
+        @RequestHeader(SECRET_HEADER) @Valid @Size(min = MIN_SECRET_LENGTH) String secretHeader,
         @RequestBody @Valid CreateDraft newDraft
     ) {
         Secrets secrets = SecretsBuilder.fromHeader(secretHeader);
@@ -126,7 +126,7 @@ public class DraftController {
         @PathVariable String id,
         @RequestHeader(AUTHORIZATION) String authHeader,
         @RequestHeader(SERVICE_HEADER) String serviceHeader,
-        @RequestHeader(SECRET_HEADER) @Valid @Length(min = MIN_SECRET_LENGTH) String secretHeader,
+        @RequestHeader(SECRET_HEADER) @Valid @Size(min = MIN_SECRET_LENGTH) String secretHeader,
         @RequestBody @Valid UpdateDraft updatedDraft
     ) {
         Secrets secrets = SecretsBuilder.fromHeader(secretHeader);


### PR DESCRIPTION
Use javax annotation instead of hibernate

```
/**
 * The annotated element size must be between the specified boundaries (included).
 * <p/>
 * Supported types are:
 * <ul>
 *     <li>{@code CharSequence} (length of character sequence is evaluated)</li>
 *     <li>{@code Collection} (collection size is evaluated)</li>
 *     <li>{@code Map} (map size is evaluated)</li>
 *     <li>Array (array length is evaluated)</li>
 * </ul>
 * <p/>
 * {@code null} elements are considered valid.
 *
 * @author Emmanuel Bernard
 */
@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
@Retention(RUNTIME)
@Documented
@Constraint(validatedBy = { })
public @interface Size {
```
`String` implements `CharSequence`.