### PR TITLE
Suppress a dependency warning

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -18,5 +18,9 @@
     <gav regex="true">^org\.codehaus\.groovy:groovy-json:.*$</gav>
     <cve>CVE-2016-6497</cve>
   </suppress>
-
+  <suppress>
+    <notes><![CDATA[Used only in tests]]></notes>
+    <gav regex="true">^org\.jetbrains:annotations:.*$</gav>
+    <cve>CVE-2017-8316</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Suppress a dependency warning, as the dependency is used in tests only. The newest version of `org.testcontainers.postgresql`, which contains the dependency, is used.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
