### PR TITLE
ROC-5323 user's document type counts report endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDaoTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDaoTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.function.Predicate.isEqual;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDaoTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDaoTest.java
@@ -10,12 +10,15 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.draftstore.data.model.CreateDraft;
+import uk.gov.hmcts.reform.draftstore.data.model.DocumentTypeCount;
 import uk.gov.hmcts.reform.draftstore.data.model.Draft;
 
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import static java.util.function.Predicate.isEqual;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -114,5 +117,39 @@ public class DraftStoreDaoTest {
 
         assertThat(result.get(1).get("service")).isEqualTo(service2);
         assertThat(result.get(1).get("count")).isEqualTo(2L);
+    }
+
+    @Test
+    public void getDraftTypeCountsByUser_should_return_empty_map_when_no_tuples() {
+        // given no tuples
+        // when
+        List<DocumentTypeCount> result = underTest.getDraftTypeCountsByUser(USER_ID);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void getDraftTypeCountsByUser_should_return_all_counts() {
+        // given
+        underTest.insert(USER_ID, "service_1", new CreateDraft("{}", null, "some_type", 123));
+        underTest.insert(USER_ID, "service_1", new CreateDraft("{}", null, "some_type", 123));
+        underTest.insert(USER_ID, "service_1", new CreateDraft("{}", null, "another_type", 123));
+
+        // when
+        List<DocumentTypeCount> results = underTest.getDraftTypeCountsByUser(USER_ID);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.stream()
+            .filter(result -> Objects.equals(result.getDocumentType(), "some_type"))
+            .filter(result -> Objects.equals(result.getCount(), 2))
+            .count())
+            .isEqualTo(1);
+        assertThat(results.stream()
+            .filter(result -> Objects.equals(result.getDocumentType(), "another_type"))
+            .filter(result -> Objects.equals(result.getCount(), 1))
+            .count())
+            .isEqualTo(1);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/ReportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/controllers/ReportController.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.draftstore.controllers;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.draftstore.service.AuthService;
+import uk.gov.hmcts.reform.draftstore.service.DraftService;
+
+import java.util.Map;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RestController
+@Validated
+@RequestMapping(
+    path = "reports",
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+public class ReportController {
+
+    private final DraftService draftService;
+    private final AuthService authService;
+
+    public ReportController(DraftService draftService, AuthService authService) {
+        this.draftService = draftService;
+        this.authService = authService;
+    }
+
+    @GetMapping(path = "/{userId}")
+    @ApiOperation("Report draft document type counts for a user")
+    @ApiResponse(code = 200, message = "Success")
+    public Map<String, Integer> getDocumentTypeCounts(
+        @PathVariable String userId,
+        @RequestHeader(AUTHORIZATION) String authHeader
+    ) {
+        authService.authenticate(authHeader);
+        return draftService.userReport(userId);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDao.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDao.java
@@ -60,7 +60,7 @@ public class DraftStoreDao {
                 .addValue("created", now)
                 .addValue("updated", now),
             keyHolder,
-            new String[]{"id"}
+            new String[] {"id"}
         );
         return keyHolder.getKey().intValue();
     }
@@ -139,7 +139,6 @@ public class DraftStoreDao {
 
     /**
      * Deletes drafts that were not updated for a specific time.
-     *
      * @return number of deleted drafts
      */
     public int deleteStaleDrafts() {

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDao.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/DraftStoreDao.java
@@ -112,8 +112,8 @@ public class DraftStoreDao {
 
     public List<DocumentTypeCount> getDraftTypeCountsByUser(String userId) {
         try {
-            return jdbcTemplate.query("SELECT document_type, COUNT(id) AS amount " +
-                    "FROM draft_document WHERE user_id = :id GROUP BY document_type",
+            return jdbcTemplate.query("SELECT document_type, COUNT(id) AS amount "
+                    + "FROM draft_document WHERE user_id = :id GROUP BY document_type",
                 new MapSqlParameterSource("id", userId),
                 (ResultSet rs, int rowNum) -> new DocumentTypeCount(rs.getString("document_type"), rs.getInt("amount")));
         } catch (EmptyResultDataAccessException e) {

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/data/model/DocumentTypeCount.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/data/model/DocumentTypeCount.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.draftstore.data.model;
+
+public class DocumentTypeCount {
+    private final String documentType;
+    private final int count;
+
+    public DocumentTypeCount(String documentType, int count) {
+        this.documentType = documentType;
+        this.count = count;
+    }
+
+    public String getDocumentType() {
+        return documentType;
+    }
+
+    public int getCount() {
+        return count;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/AuthService.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/AuthService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.draftstore.service;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.draftstore.service.idam.IdamClient;
+import uk.gov.hmcts.reform.draftstore.service.idam.User;
 import uk.gov.hmcts.reform.draftstore.service.s2s.S2sClient;
 
 @Service
@@ -23,5 +24,9 @@ public class AuthService {
             idamClient.getUserDetails(userHeader).id,
             s2sClient.getServiceName(serviceHeader)
         );
+    }
+
+    public User authenticate(String userHeader) {
+        return idamClient.getUserDetails(userHeader);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/draftstore/service/DraftService.java
+++ b/src/main/java/uk/gov/hmcts/reform/draftstore/service/DraftService.java
@@ -11,7 +11,9 @@ import uk.gov.hmcts.reform.draftstore.domain.UpdateDraft;
 import uk.gov.hmcts.reform.draftstore.exception.AuthorizationException;
 import uk.gov.hmcts.reform.draftstore.exception.NoDraftFoundException;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -48,6 +50,11 @@ public class DraftService {
                 .collect(toList());
 
         return new DraftList(drafts);
+    }
+
+    public Map<String, Integer> userReport(String userId) {
+        return draftRepo.getDraftTypeCountsByUser(userId).stream()
+            .collect(HashMap::new, (map, count) -> map.put(count.getDocumentType(), count.getCount()), Map::putAll);
     }
 
     public int create(CreateDraft newDraft, UserAndService userAndService) {

--- a/src/test/java/uk/gov/hmcts/reform/draftstore/service/draftservice/UserReportTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/draftstore/service/draftservice/UserReportTest.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.draftstore.service.draftservice;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.draftstore.data.model.DocumentTypeCount;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserReportTest extends BaseTest {
+    @Test
+    public void should_return_empty_map() {
+        when(repo.getDraftTypeCountsByUser(anyString()))
+            .thenReturn(emptyList());
+
+        Map<String, Integer> results = draftService.userReport("1");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    public void should_pass_through_results() {
+        when(repo.getDraftTypeCountsByUser(anyString()))
+            .thenReturn(Arrays.asList(
+                new DocumentTypeCount("claim", 1),
+                new DocumentTypeCount("response", 2)
+            ));
+
+        Map<String, Integer> results = draftService.userReport("1");
+
+        assertThat(results).containsOnlyKeys("claim", "response");
+        assertThat(results.get("claim")).isEqualTo(1);
+        assertThat(results.get("response")).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-5323

### Change description ###
Add reports endpoint to query the draft document type counts of a user.
Caller must be signed in to IDaM but there are no further role restrictions in place.
This is to facilitate Live Support work.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
