### PR TITLE
Spring boot 2.4 upgrade with configtree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ configurations.all {
         details.useVersion '2.12.10'
       }
       if (details.requested.group in ['org.apache.tomcat.embed']) {
-        details.useVersion '9.0.37'
+        details.useVersion '9.0.44'
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,15 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'pmd'
-  id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.flywaydb.flyway' version '6.5.7'
-  id 'org.springframework.boot' version '2.3.4.RELEASE'
-  id 'uk.gov.hmcts.java' version '0.12.2'
-  id 'com.github.ben-manes.versions' version '0.36.0'
-  id 'org.sonarqube' version '3.0'
+  id 'org.springframework.boot' version '2.4.3'
+  id 'uk.gov.hmcts.java' version '0.12.5'
+  id 'com.github.ben-manes.versions' version '0.38.0'
+  id 'org.sonarqube' version '3.1.1'
   id 'scala'
-  id 'com.github.lkishalmi.gatling' version '3.3.0'
-  id 'au.com.dius.pact' version '4.1.11'
+  id 'com.github.lkishalmi.gatling' version '3.3.4'
+  id 'au.com.dius.pact' version '4.2.2'
 }
 
 group 'uk.gov.hmcts.reform'
@@ -174,9 +174,9 @@ repositories {
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
 // enforces it's own (older) version which is not recommended.
 def versions = [
-  junit: '5.6.2',
-  junitPlatform: '1.6.2',
-  logging: '5.1.5',
+  junit: '5.7.1',
+  junitPlatform: '1.7.1',
+  logging: '5.1.7',
   springBoot: springBoot.class.package.implementationVersion,
   springfoxSwagger: '2.9.2',
   pact_version: '4.1.7'
@@ -207,7 +207,7 @@ dependencies {
     "org.springframework.boot:spring-boot-starter-jdbc",
     "org.springframework.boot:spring-boot-starter-validation",
   )
-  compile group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
+  compile group: 'org.postgresql', name: 'postgresql', version: '42.2.19'
 
   compile group: 'org.flywaydb', name: 'flyway-core', version: '6.5.7'
 
@@ -217,19 +217,18 @@ dependencies {
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
-  compile group: 'com.google.guava', name: 'guava', version: '30.0-jre'
+  compile group: 'com.google.guava', name: 'guava', version: '30.1-jre'
 
   compile group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.logging
   compile group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.logging
   compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.logging
 
-  compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.0'
-  compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.0'
+  compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
+  compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.1'
 
   compile group: 'uk.gov.hmcts.reform', name: 'reform-api-standards', version: '0.4.0'
-  compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
 
-  compile group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.6.1'
+  compile group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.6.4'
 
   testCompile group: 'io.rest-assured', name: 'rest-assured'
 
@@ -241,7 +240,7 @@ dependencies {
   testCompile group: 'org.junit.platform', name: 'junit-platform-commons', version: versions.junitPlatform
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-  testCompile group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
+    testCompile group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
   testCompile 'org.testcontainers:postgresql:1.15.0'
 
   integrationTestCompile sourceSets.main.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,7 @@ dependencies {
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     testCompile group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
-  testCompile 'org.testcontainers:postgresql:1.15.0'
+    testCompile 'org.testcontainers:postgresql:1.15.2'
 
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath

--- a/charts/draft-store-service/Chart.yaml
+++ b/charts/draft-store-service/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: draft-store-service
 home: https://github.com/hmcts/draft-store
-version: 2.0.12
+version: 2.0.13
 description: Draft store
 maintainers:
   - name: HMCTS Platform engineering team
 dependencies:
   - name: java
-    version: 3.4.4
+    version: 3.4.5
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/

--- a/charts/draft-store-service/values.preview.template.yaml
+++ b/charts/draft-store-service/values.preview.template.yaml
@@ -9,6 +9,6 @@ java:
     DRAFT_STORE_DB_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     RUN_DB_MIGRATION_ON_STARTUP: true
     DRAFT_STORE_DB_CONN_OPTIONS: ""
-    SPRING_CLOUD_PROPERTIESVOLUME_ENABLED: false
+  disableKeyVaults: true
   postgresql:
     enabled: true

--- a/charts/draft-store-service/values.yaml
+++ b/charts/draft-store-service/values.yaml
@@ -17,5 +17,7 @@ java:
   keyVaults:
     "draft-store":
       secrets:
-        - service-POSTGRES-PASS
-        - AppInsightsInstrumentationKey
+        - name: service-POSTGRES-PASS
+          alias: DRAFT_STORE_DB_PASSWORD
+        - name: AppInsightsInstrumentationKey
+          alias: azure.application-insights.instrumentation-key

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,14 +54,18 @@ dbMigration:
 
 ---
 spring:
-  profiles: test
+  config:
+    activate:
+      on-profile: test
   datasource:
     url: jdbc:postgresql://localhost:${DRAFT_STORE_DB_PORT:5432}/draftstore
     password: ${DRAFT_STORE_DB_PASSWORD:}
 
 ---
 spring:
-  profiles: test-unhandled-exception
+  config:
+    activate:
+      on-profile: test-unhandled-exception
   datasource:
     url: jdbc:postgresql://localhost:${DRAFT_STORE_DB_PORT:5432}/draftstore
     password: ${DRAFT_STORE_DB_PASSWORD:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,6 @@
 logging:
   level:
     ROOT: info
-
 spring:
   application:
     name: HMCTS Draft Store
@@ -13,7 +12,8 @@ spring:
       charSet: UTF-8
   mvc:
     throw-exception-if-no-handler-found: true
-
+  config:
+    import: "optional:configtree:/mnt/secrets/draft-store/"
 server:
   port: 8800
 

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -1,8 +1,0 @@
-spring:
-  cloud:
-    propertiesvolume:
-      prefixed: false
-      paths: /mnt/secrets/draft-store
-      aliases:
-        service-POSTGRES-PASS: DRAFT_STORE_DB_PASSWORD
-        AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key


### PR DESCRIPTION
- Use spring boot configtree instead of properties-volume-springboot-starter
- Change to use `disableKeyvaults`in preview as `SPRING_CLOUD_PROPERTIESVOLUME_ENABLED` won't work anymore.
- Using alias in secretproviderclass to rename secrets to env vars/spring properties.
- Also upgrades other dependencies as there were bunch of vulnerabilities.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
