### PR TITLE
DTSPO-17910 - Change create_mode

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,5 +1,5 @@
 idam_api_url                = "https://idam-api.aat.platform.hmcts.net"
 idam_redirect_uri_for_tests = "https://cmc-citizen-frontend-aat-staging.service.core-compute-aat.internal/receiver"
-pgsql_create_mode           = "Default"
+pgsql_create_mode           = "Update"
 pgsql_version               = "15"
 

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,5 +1,5 @@
 idam_api_url                = "https://idam-api.aat.platform.hmcts.net"
 idam_redirect_uri_for_tests = "https://cmc-citizen-frontend-aat-staging.service.core-compute-aat.internal/receiver"
-pgsql_create_mode           = "Update"
+pgsql_create_mode           = "Default"
 pgsql_version               = "15"
 

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -1,3 +1,3 @@
 idam_api_url      = "http://betadevbccidamapplb.reform.hmcts.net"
-pgsql_create_mode = "Update"
+pgsql_create_mode = "Default"
 pgsql_version     = "15"

--- a/infrastructure/test_config.tf
+++ b/infrastructure/test_config.tf
@@ -8,7 +8,7 @@ data "azurerm_key_vault" "s2s_vault" {
 
 data "azurerm_key_vault_secret" "source_s2s-secret-for-tests" {
   name         = "microservicekey-draftStoreTests"
-  key_vault_id = "${data.azurerm_key_vault.s2s_vault.id}"
+  key_vault_id = data.azurerm_key_vault.s2s_vault.id
 }
 
 resource "azurerm_key_vault_secret" "s2s-secret-for-tests" {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-17912

### Change description ###
Change create mode to default from update
This is causing a 404 error when deploying but the update mode should only be used when updating the postgres version as well
![Screenshot 2024-07-16 at 15 00 54](https://github.com/user-attachments/assets/be17af22-8189-49e5-bb3a-6af005e60ffd)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
